### PR TITLE
Reorganize key names

### DIFF
--- a/js/forum/src/addComposerAutocomplete.js
+++ b/js/forum/src/addComposerAutocomplete.js
@@ -108,7 +108,7 @@ export default function addComposerAutocomplete() {
                   const user = post.user();
                   suggestions.push(
                     makeSuggestion(user, '@' + user.username() + '#' + post.id(), [
-                      app.translator.trans('flarum-mentions.forum.reply_to_post', {number: post.number()}), ' — ',
+                      app.translator.trans('flarum-mentions.forum.composer.reply_to_post_text', {number: post.number()}), ' — ',
                       truncate(post.contentPlain(), 200)
                     ], 'MentionsDropdown-post')
                   );

--- a/js/forum/src/addMentionedByList.js
+++ b/js/forum/src/addMentionedByList.js
@@ -70,6 +70,8 @@ export default function addMentionedByList() {
         });
       };
 
+// NEEDS TO BE FIXED: The next two blocks of code. See https://github.com/flarum/core/issues/597 for details.
+
       // Create a list of unique users who have replied. So even if a user has
       // replied twice, they will only be in this array once.
       const used = [];
@@ -91,7 +93,7 @@ export default function addMentionedByList() {
               config={m.route}
               onclick={hidePreview}
               data-number={reply.number()}>
-              {app.session.user === user ? app.translator.trans('flarum-mentions.forum.you') : username(user)}
+              {app.session.user === user ? app.translator.trans('flarum-mentions.forum.post.you_text') : username(user)}
             </a>
           );
         });
@@ -100,7 +102,8 @@ export default function addMentionedByList() {
         <div className="Post-mentionedBy" config={config}>
           <span className="Post-mentionedBy-summary">
             {icon('reply')}
-            {app.translator.trans('flarum-mentions.forum.post_mentioned_by', {
+            // PLEASE CHECK: Using the syntax from "addLikesList.js" with "repliers[0]" in place of "likes[0]".
+            {app.translator.transChoice('flarum-mentions.forum.post.mentioned_by' + (repliers[0] === app.session.user ? '_self' : '') + '_text', names.length, {
               count: names.length,
               users: punctuateSeries(names)
             })}

--- a/js/forum/src/addPostReplyAction.js
+++ b/js/forum/src/addPostReplyAction.js
@@ -31,7 +31,7 @@ export default function() {
     items.add('reply',
       Button.component({
         className: 'Button Button--link',
-        children: app.translator.trans('flarum-mentions.forum.reply_link'),
+        children: app.translator.trans('flarum-mentions.forum.post.reply_link'),
         onclick: () => {
           const quote = window.getSelection().toString();
 

--- a/js/forum/src/components/PostMentionedNotification.js
+++ b/js/forum/src/components/PostMentionedNotification.js
@@ -1,6 +1,6 @@
 import Notification from 'flarum/components/Notification';
 import username from 'flarum/helpers/username';
-import punctuate from 'flarum/helpers/punctuate';
+import punctuateSeries from 'flarum/helpers/punctuateSeries';
 
 export default class PostMentionedNotification extends Notification {
   icon() {
@@ -21,11 +21,11 @@ export default class PostMentionedNotification extends Notification {
     const auc = notification.additionalUnreadCount();
     const user = notification.sender();
 
-    return app.translator.trans('flarum-mentions.forum.post_mentioned_notification', {
+    return app.translator.trans('flarum-mentions.forum.notifications.post_mentioned_text', {
       user,
-      username: auc ? punctuate([
+      username: auc ? punctuateSeries([
         username(user),
-        app.translator.trans('flarum-mentions.forum.others', {count: auc})
+        app.translator.trans('flarum-mentions.forum.notifications.others_text', {count: auc})
       ]) : undefined
     });
   }

--- a/js/forum/src/components/UserMentionedNotification.js
+++ b/js/forum/src/components/UserMentionedNotification.js
@@ -14,7 +14,7 @@ export default class UserMentionedNotification extends Notification {
   content() {
     const user = this.props.notification.sender();
 
-    return app.translator.trans('flarum-mentions.forum.user_mentioned_notification', {user});
+    return app.translator.trans('flarum-mentions.forum.notifications.user_mentioned_text', {user});
   }
 
   excerpt() {

--- a/js/forum/src/main.js
+++ b/js/forum/src/main.js
@@ -35,13 +35,13 @@ app.initializers.add('flarum-mentions', function() {
     items.add('postMentioned', {
       name: 'postMentioned',
       icon: 'reply',
-      label: app.translator.trans('flarum-mentions.forum.notify_post_mentioned')
+      label: app.translator.trans('flarum-mentions.forum.settings.notify_post_mentioned_label')
     });
 
     items.add('userMentioned', {
       name: 'userMentioned',
       icon: 'at',
-      label: app.translator.trans('flarum-mentions.forum.notify_user_mentioned')
+      label: app.translator.trans('flarum-mentions.forum.settings.notify_user_mentioned_label')
     });
   });
 


### PR DESCRIPTION
See [flarum/core #265](https://github.com/flarum/core/issues/265).

- Adjusts key names to three-tier namespacing.
- Extracts previously unextracted strings.
- Changes an instance of `punctuate` to `punctuateSeries`.
- Modifies the syntax of **addMentionedByLIst.js** slightly.