### PR TITLE
Check reply with mention can be read by original poster

### DIFF
--- a/src/Listener/UpdateMentionsMetadataWhenVisible.php
+++ b/src/Listener/UpdateMentionsMetadataWhenVisible.php
@@ -76,7 +76,7 @@ class UpdateMentionsMetadataWhenVisible
             ->whereIn('id', $mentioned)
             ->get()
             ->filter(function ($post) use ($reply) {
-                return $post->user && $post->user->id !== $reply->user_id;
+                return $post->user && $post->user->id !== $reply->user_id && $reply->isVisibleTo($post->user);
             })
             ->all();
 


### PR DESCRIPTION
When combining the mention extension with the Private Discussion extension, it is possible to notify the author of a mentioned post of the contents of a private discussion that contains the quoted text.

Steps to reproduce:

1. Log in as User A, create a discussion
2. Log in as User B, go to discussion from point 1, quote the post.
3. Copy this quote and start a new discussion, set recipients to someone other than user A (e.g. user C), thus creating a Private Discussion without User A.
4. User A gets notified that they have been mentioned in discussion from point 4, even if they do not have access to it.

The change doesn't use the PD code, rather it utilises the existing visibility mechanism which I feel is much cleaner, not coupled with PD and has the potential to resolve issues with any other extensions with visibility issues for mentions. 
 