### PR TITLE
Adding rel="noindex" to post mentions

### DIFF
--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -84,7 +84,7 @@ class ConfigureMentions
         $tag->attributes->add('discussionid')->filterChain->append('#uint');
         $tag->attributes->add('id')->filterChain->append('#uint');
 
-        $tag->template = '<a href="{$DISCUSSION_URL}{@discussionid}/{@number}" rel="nofollow" class="PostMention" data-id="{@id}"><xsl:value-of select="@displayname"/></a>';
+        $tag->template = '<a href="{$DISCUSSION_URL}{@discussionid}/{@number}" rel="noindex" class="PostMention" data-id="{@id}"><xsl:value-of select="@displayname"/></a>';
 
         $tag->filterChain
             ->prepend([static::class, 'addPostId'])

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -84,7 +84,7 @@ class ConfigureMentions
         $tag->attributes->add('discussionid')->filterChain->append('#uint');
         $tag->attributes->add('id')->filterChain->append('#uint');
 
-        $tag->template = '<a href="{$DISCUSSION_URL}{@discussionid}/{@number}" class="PostMention" data-id="{@id}"><xsl:value-of select="@displayname"/></a>';
+        $tag->template = '<a href="{$DISCUSSION_URL}{@discussionid}/{@number}" rel="nofollow" class="PostMention" data-id="{@id}"><xsl:value-of select="@displayname"/></a>';
 
         $tag->filterChain
             ->prepend([static::class, 'addPostId'])


### PR DESCRIPTION
This should fix the problem of google indexing the same discussion multiple times. The issue that it actually causes can be seen by going [here](https://www.google.com/search?q=site%3Ahttps%3A%2F%2Fdiscuss.flarum.org%2Fd%2F187-word-association-game) by setting post mentions to no index the discussion will not by indexed every single time a post is mentioned. Thus increasing the amount of time the bots can spend scanning new discussions and ensures that searches don't return the the same discussion multiple times (searching `flarum word association game`) is an excellent example of this problem.