### PR TITLE
fix: Determine if a post has a user before setting mention details

### DIFF
--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -99,7 +99,7 @@ class ConfigureMentions
     {
         $post = CommentPost::find($tag->getAttribute('id'));
 
-        if ($post) {
+        if ($post->user) {
             $tag->setAttribute('discussionid', (int) $post->discussion_id);
             $tag->setAttribute('number', (int) $post->number);
             $tag->setAttribute('displayname', $post->user->display_name);

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -99,7 +99,7 @@ class ConfigureMentions
     {
         $post = CommentPost::find($tag->getAttribute('id'));
 
-        if ($post->user) {
+        if ($post && $post->user) {
             $tag->setAttribute('discussionid', (int) $post->discussion_id);
             $tag->setAttribute('number', (int) $post->number);
             $tag->setAttribute('displayname', $post->user->display_name);


### PR DESCRIPTION
Fixes flarum/core#1956 - ErrorException: Trying to get property 'display_name' of 
non-object. ConfigureMentions::addPostId method set mention details 
based on if there was an existing post. This caused an error if there 
was an existing post, but the user who posted had been deleted. The 
mention details are now only set if there is a user associated with the 
post being mentioned.