### PR TITLE
Approval improve

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -11,6 +11,7 @@
 
 use Flarum\Api\Event\WillSerializeData;
 use Flarum\Api\Serializer\PostSerializer;
+use Flarum\Approval\Event\PostWasApproved;
 use Flarum\Event\ConfigureNotificationTypes;
 use Flarum\Event\ConfigurePostsQuery;
 use Flarum\Extend;
@@ -44,7 +45,7 @@ return [
             $event->add(UserMentionedBlueprint::class, PostSerializer::class, ['alert']);
         });
         $events->listen(
-            [Posted::class, Restored::class, Revised::class],
+            [Posted::class, Restored::class, Revised::class, PostWasApproved::class],
             Listener\UpdateMentionsMetadataWhenVisible::class
         );
         $events->listen(

--- a/src/Listener/UpdateMentionsMetadataWhenVisible.php
+++ b/src/Listener/UpdateMentionsMetadataWhenVisible.php
@@ -76,7 +76,7 @@ class UpdateMentionsMetadataWhenVisible
             ->whereIn('id', $mentioned)
             ->get()
             ->filter(function ($post) use ($reply) {
-                return $post->user && $post->user->id !== $reply->user_id;
+                return $post->user && $reply->isVisibleTo($post->user) && $post->user->id !== $reply->user_id;
             })
             ->all();
 


### PR DESCRIPTION
When open notifications about ``Someone replies to one of my posts`` and ``Someone mentions me in a post``, besides enabled extension ``flarum/approval`` on admin dashboard. I didn't receive a notification when the admin approve the post about replied to me or mentioned to me. Now, I fix it.