### PR TITLE
fix: Inline spoilers

### DIFF
--- a/less/forum.less
+++ b/less/forum.less
@@ -12,6 +12,12 @@
   &:active {
     color: @link-color;
   }
+
+  .spoiler & {
+    background: #444;
+    color: transparent;
+    padding: 0;
+  }
 }
 .PostMention {
   margin: 0 3px;


### PR DESCRIPTION
This fixes the mentions in inline spoilers

Part of the fix for https://github.com/flarum/core/issues/2053

Before Clicking:
![image](https://user-images.githubusercontent.com/3457368/76146558-c9165680-6061-11ea-8925-234a9ed16672.png)

After Clicking:
![image](https://user-images.githubusercontent.com/3457368/76146561-d3d0eb80-6061-11ea-8137-51ff114876d8.png)
