### PR TITLE
Always show replies list on posts

### DIFF
--- a/js/src/forum/addMentionedByList.js
+++ b/js/src/forum/addMentionedByList.js
@@ -15,12 +15,6 @@ export default function addMentionedByList() {
     const replies = post.mentionedBy();
 
     if (replies && replies.length) {
-      // If there is only one reply, and it's adjacent to this post, we don't
-      // really need to show the list.
-      if (replies.length === 1 && replies[0].number() === post.number() + 1) {
-        return;
-      }
-
       const hidePreview = () => {
         this.$('.Post-mentionedBy-preview')
           .removeClass('in')


### PR DESCRIPTION
Previously, if there was a single reply and it was adjacent to the post it wasn't shown.

See discussion on Discuss: https://discuss.flarum.org/d/23666-flarum-010-beta13-released/75