### PR TITLE
Stop mentions dropdown from jumping around

### DIFF
--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -179,7 +179,9 @@ export default function addComposerAutocomplete() {
           dropdown.$().scrollTop(0);
 
           clearTimeout(searchTimeout);
-          if (typed) {
+          // Don't send API calls searching for users until at least 2 characters have been typed.
+          // This focuses the mention results on users and posts in the discussion.
+          if (typed.length > 1) {
             searchTimeout = setTimeout(function() {
               const typedLower = typed.toLowerCase();
               if (searched.indexOf(typedLower) === -1) {

--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -109,18 +109,6 @@ export default function addComposerAutocomplete() {
           const buildSuggestions = () => {
             const suggestions = [];
 
-            // If the user has started to type a username, then suggest users
-            // matching that username.
-            if (typed) {
-              app.store.all('users').forEach(user => {
-                if (!userMatches(user)) return;
-
-                suggestions.push(
-                  makeSuggestion(user, '@' + user.username(), '', 'MentionsDropdown-user')
-                );
-              });
-            }
-
             // If the user is replying to a discussion, or if they are editing a
             // post, then we can suggest other posts in the discussion to mention.
             // We will add the 5 most recent comments in the discussion which
@@ -145,6 +133,18 @@ export default function addComposerAutocomplete() {
                     ], 'MentionsDropdown-post')
                   );
                 });
+            }
+
+            // If the user has started to type a username, then suggest users
+            // matching that username.
+            if (typed) {
+              app.store.all('users').forEach(user => {
+                if (!userMatches(user)) return;
+
+                suggestions.push(
+                  makeSuggestion(user, '@' + user.username(), '', 'MentionsDropdown-user')
+                );
+              });
             }
 
             if (suggestions.length) {


### PR DESCRIPTION
- Cache the order in which users are returned by the API to stop the mentions list from jumping around
- Only ping the api when 2 or more characters are entered 