### PR TITLE
Incorrect display_name showing in email notifications

### DIFF
--- a/src/Notification/PostMentionedBlueprint.php
+++ b/src/Notification/PostMentionedBlueprint.php
@@ -74,7 +74,7 @@ class PostMentionedBlueprint implements BlueprintInterface, MailableInterface
     public function getEmailSubject(TranslatorInterface $translator)
     {
         return $translator->trans('flarum-mentions.email.post_mentioned.subject', [
-            '{replier_display_name}' => $this->post->user->display_name,
+            '{replier_display_name}' => $this->reply->user->display_name,
             '{title}' => $this->post->discussion->title
         ]);
     }

--- a/views/emails/postMentioned.blade.php
+++ b/views/emails/postMentioned.blade.php
@@ -1,6 +1,6 @@
 {!! $translator->trans('flarum-mentions.email.post_mentioned.body', [
 '{recipient_display_name}' => $user->display_name,
-'{replier_display_name}' => $blueprint->post->user->display_name,
+'{replier_display_name}' => $blueprint->reply->user->display_name,
 '{post_number}' => $blueprint->post->number,
 '{title}' => $blueprint->post->discussion->title,
 '{url}' => $url->to('forum')->route('discussion', ['id' => $blueprint->reply->discussion_id, 'near' => $blueprint->reply->number]),


### PR DESCRIPTION
Using beta.15:

A postmention email notification incorrectly displays the `post` display_name, rather than the `reply` display_name:

![image](https://user-images.githubusercontent.com/16573496/102762012-9a0e6e80-436f-11eb-99f5-8b8141ed3c04.png)
