### PR TITLE
Eager load mentionedBy and only missing relations

### DIFF
--- a/src/FilterVisiblePosts.php
+++ b/src/FilterVisiblePosts.php
@@ -66,7 +66,7 @@ class FilterVisiblePosts
             // Load all of the users that these posts mention. This way the data
             // will be ready to go when we need to sub in current usernames
             // during the rendering process.
-            $posts->load(['mentionsUsers', 'mentionsPosts.user']);
+            $posts->loadMissing(['mentionsUsers', 'mentionsPosts.user', 'mentionedBy']);
 
             // Construct a list of the IDs of all of the posts that these posts
             // have been mentioned in. We can then filter this list of IDs to


### PR DESCRIPTION
**Part of flarum/core#2637**

`mentionedBy` is accessed in the same class a little below but not eager loaded, additionally we want to only eager load relations that weren't loaded before, otherwise it can end up forgetting about the previously eager loaded relations.

![flarum lan___clockwork_app (3)](https://user-images.githubusercontent.com/20267363/111916087-8f9c6780-8a79-11eb-8dda-2c0f00d3c586.png)
![flarum lan___clockwork_app (4)](https://user-images.githubusercontent.com/20267363/111916090-932fee80-8a79-11eb-95b6-350ec7b45aa2.png)
