### PR TITLE
New mentions format, decouple usernames from mentions

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -34,7 +34,8 @@ return [
     (new Extend\Formatter)
         ->configure(ConfigureMentions::class)
         ->render(Formatter\FormatPostMentions::class)
-        ->render(Formatter\FormatUserMentions::class),
+        ->render(Formatter\FormatUserMentions::class)
+        ->unparse(Formatter\UnparseUserMentions::class),
 
     (new Extend\Model(Post::class))
         ->belongsToMany('mentionedBy', Post::class, 'post_mentions_post', 'mentions_post_id', 'post_id')

--- a/extend.php
+++ b/extend.php
@@ -35,6 +35,7 @@ return [
         ->configure(ConfigureMentions::class)
         ->render(Formatter\FormatPostMentions::class)
         ->render(Formatter\FormatUserMentions::class)
+        ->unparse(Formatter\UnparsePostMentions::class)
         ->unparse(Formatter\UnparseUserMentions::class),
 
     (new Extend\Model(Post::class))

--- a/extend.php
+++ b/extend.php
@@ -75,6 +75,9 @@ return [
     (new Extend\ApiController(Controller\AbstractSerializeController::class))
         ->prepareDataForSerialization(FilterVisiblePosts::class),
 
+    (new Extend\Settings)
+        ->serializeToForum('allowUsernameMentionFormat', 'flarum-mentions.allow_username_format', 'boolval'),
+
     (new Extend\Event())
         ->listen(Posted::class, Listener\UpdateMentionsMetadataWhenVisible::class)
         ->listen(Restored::class, Listener\UpdateMentionsMetadataWhenVisible::class)

--- a/extend.php
+++ b/extend.php
@@ -31,6 +31,9 @@ return [
         ->js(__DIR__.'/js/dist/forum.js')
         ->css(__DIR__.'/less/forum.less'),
 
+    (new Extend\Frontend('admin'))
+        ->js(__DIR__.'/js/dist/admin.js'),
+
     (new Extend\Formatter)
         ->configure(ConfigureMentions::class)
         ->render(Formatter\FormatPostMentions::class)

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,1 @@
+export * from './src/admin';

--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -4,6 +4,7 @@ app.initializers.add('flarum-mentions', function() {
     .registerSetting({
       setting: 'flarum-mentions.allow_username_format',
       type: 'boolean',
-      label: app.translator.trans('flarum-mentions.admin.settings.allow_username_format')
+      label: app.translator.trans('flarum-mentions.admin.settings.allow_username_format_label'),
+      help: app.translator.trans('flarum-mentions.admin.settings.allow_username_format_text')
     });
 });

--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -1,0 +1,9 @@
+app.initializers.add('flarum-mentions', function() {
+  app.extensionData
+    .for('flarum-mentions')
+    .registerSetting({
+      setting: 'flarum-mentions.allow_username_format',
+      type: 'boolean',
+      label: app.translator.trans('flarum-mentions.admin.settings.allow_username_format')
+    });
+});

--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -10,6 +10,7 @@ import KeyboardNavigatable from 'flarum/utils/KeyboardNavigatable';
 import { truncate } from 'flarum/utils/string';
 
 import AutocompleteDropdown from './fragments/AutocompleteDropdown';
+import cleanDisplayName from './utils/cleanDisplayName';
 
 export default function addComposerAutocomplete() {
   const $container = $('<div class="ComposerBody-mentionsDropdownContainer"></div>');
@@ -116,7 +117,7 @@ export default function addComposerAutocomplete() {
                 if (!userMatches(user)) return;
 
                 suggestions.push(
-                  makeSuggestion(user, `@"${user.displayName().replace(/"#[a-z]{0,3}[0-9]+/, '_')}"#${user.id()}`, '', 'MentionsDropdown-user')
+                  makeSuggestion(user, `@"${cleanDisplayName(user)}"#${user.id()}`, '', 'MentionsDropdown-user')
                 );
               });
             }
@@ -142,7 +143,7 @@ export default function addComposerAutocomplete() {
                   .forEach(post => {
                     const user = post.user();
                     suggestions.push(
-                      makeSuggestion(user, `@"${user.displayName().replace(/"#[a-z]{0,3}[0-9]+/, '_')}"#p${post.id()}`, [
+                      makeSuggestion(user, `@"${cleanDisplayName(user)}"#p${post.id()}`, [
                         app.translator.trans('flarum-mentions.forum.composer.reply_to_post_text', {number: post.number()}), ' — ',
                         truncate(post.contentPlain(), 200)
                       ], 'MentionsDropdown-post')

--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -142,7 +142,7 @@ export default function addComposerAutocomplete() {
                   .forEach(post => {
                     const user = post.user();
                     suggestions.push(
-                      makeSuggestion(user, '@' + user.username() + '#' + post.id(), [
+                      makeSuggestion(user, `@"${user.displayName()}"#p${post.id()}`, [
                         app.translator.trans('flarum-mentions.forum.composer.reply_to_post_text', {number: post.number()}), ' — ',
                         truncate(post.contentPlain(), 200)
                       ], 'MentionsDropdown-post')

--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -116,7 +116,7 @@ export default function addComposerAutocomplete() {
                 if (!userMatches(user)) return;
 
                 suggestions.push(
-                  makeSuggestion(user, '@' + user.username(), '', 'MentionsDropdown-user')
+                  makeSuggestion(user, `@"${user.displayName()}"#${user.id()}`, '', 'MentionsDropdown-user')
                 );
               });
             }

--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -76,7 +76,7 @@ export default function addComposerAutocomplete() {
 
         if (absMentionStart) {
           typed = lastChunk.substring(relMentionStart).toLowerCase();
-          matchTyped = typed.match(/"((?:(?!"#).)+)/);
+          matchTyped = typed.match(/^"((?:(?!"#).)+)$/);
           typed = (matchTyped && matchTyped[1]) || typed;
 
           const makeSuggestion = function(user, replacement, content, className = '') {

--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -36,6 +36,7 @@ export default function addComposerAutocomplete() {
     let relMentionStart;
     let absMentionStart;
     let typed;
+    let matchTyped;
     let searchTimeout;
 
     // We store users returned from an API here to preserve order in which they are returned
@@ -75,6 +76,8 @@ export default function addComposerAutocomplete() {
 
         if (absMentionStart) {
           typed = lastChunk.substring(relMentionStart).toLowerCase();
+          matchTyped = typed.match(/"((?:(?!"#).)+)/);
+          typed = (matchTyped && matchTyped[1]) || typed;
 
           const makeSuggestion = function(user, replacement, content, className = '') {
             const username = usernameHelper(user);

--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -116,7 +116,7 @@ export default function addComposerAutocomplete() {
                 if (!userMatches(user)) return;
 
                 suggestions.push(
-                  makeSuggestion(user, `@"${user.displayName()}"#${user.id()}`, '', 'MentionsDropdown-user')
+                  makeSuggestion(user, `@"${user.displayName().replace(/"#[a-z]{0,3}[0-9]+/, '_')}"#${user.id()}`, '', 'MentionsDropdown-user')
                 );
               });
             }
@@ -142,7 +142,7 @@ export default function addComposerAutocomplete() {
                   .forEach(post => {
                     const user = post.user();
                     suggestions.push(
-                      makeSuggestion(user, `@"${user.displayName()}"#p${post.id()}`, [
+                      makeSuggestion(user, `@"${user.displayName().replace(/"#[a-z]{0,3}[0-9]+/, '_')}"#p${post.id()}`, [
                         app.translator.trans('flarum-mentions.forum.composer.reply_to_post_text', {number: post.number()}), ' — ',
                         truncate(post.contentPlain(), 200)
                       ], 'MentionsDropdown-post')

--- a/js/src/forum/addPostMentionPreviews.js
+++ b/js/src/forum/addPostMentionPreviews.js
@@ -14,12 +14,12 @@ export default function addPostMentionPreviews() {
     const parentPost = this.attrs.post;
     const $parentPost = this.$();
 
-    this.$().on('click', '.UserMention, .PostMention', function (e) {
+    this.$().on('click', '.UserMention:not(.UserMention--deleted), .PostMention:not(.PostMention--deleted)', function (e) {
       m.route.set(this.getAttribute('href'));
       e.preventDefault();
     });
 
-    this.$('.PostMention').each(function() {
+    this.$('.PostMention:not(.PostMention--deleted)').each(function() {
       const $this = $(this);
       const id = $this.data('id');
       let timeout;

--- a/js/src/forum/utils/cleanDisplayName.js
+++ b/js/src/forum/utils/cleanDisplayName.js
@@ -1,0 +1,3 @@
+export default function cleanDisplayName(user) {
+  return user.displayName().replace(/"#[a-z]{0,3}[0-9]+/, '_');
+};

--- a/js/src/forum/utils/reply.js
+++ b/js/src/forum/utils/reply.js
@@ -3,7 +3,7 @@ import EditPostComposer from 'flarum/components/EditPostComposer';
 
 function insertMention(post, composer, quote) {
   const user = post.user();
-  const mention = '@' + (user ? user.username() : post.number()) + '#' + post.id() + ' ';
+  const mention = `@"${(user && user.displayName()) || app.translator.trans('core.lib.username.deleted_text')}"#p${post.id()}`;
 
   // If the composer is empty, then assume we're starting a new reply.
   // In which case we don't want the user to have to confirm if they

--- a/js/src/forum/utils/reply.js
+++ b/js/src/forum/utils/reply.js
@@ -3,7 +3,7 @@ import EditPostComposer from 'flarum/components/EditPostComposer';
 
 function insertMention(post, composer, quote) {
   const user = post.user();
-  const mention = `@"${(user && user.displayName()) || app.translator.trans('core.lib.username.deleted_text')}"#p${post.id()}`;
+  const mention = `@"${(user && user.displayName().replace(/"#[a-z]{0,3}[0-9]+/, '_')) || app.translator.trans('core.lib.username.deleted_text')}"#p${post.id()}`;
 
   // If the composer is empty, then assume we're starting a new reply.
   // In which case we don't want the user to have to confirm if they

--- a/js/src/forum/utils/reply.js
+++ b/js/src/forum/utils/reply.js
@@ -1,9 +1,10 @@
 import DiscussionControls from 'flarum/utils/DiscussionControls';
 import EditPostComposer from 'flarum/components/EditPostComposer';
+import cleanDisplayName from './cleanDisplayName';
 
 function insertMention(post, composer, quote) {
   const user = post.user();
-  const mention = `@"${(user && user.displayName().replace(/"#[a-z]{0,3}[0-9]+/, '_')) || app.translator.trans('core.lib.username.deleted_text')}"#p${post.id()}`;
+  const mention = `@"${(user && cleanDisplayName(user)) || app.translator.trans('core.lib.username.deleted_text')}"#p${post.id()}`;
 
   // If the composer is empty, then assume we're starting a new reply.
   // In which case we don't want the user to have to confirm if they

--- a/js/src/forum/utils/textFormatter.js
+++ b/js/src/forum/utils/textFormatter.js
@@ -4,9 +4,9 @@ import extractText from 'flarum/utils/extractText';
 export function filterUserMentions(tag) {
   let user;
 
-  if (tag.hasAttribute('username'))
+  if (app.forum.attribute('allowUsernameMentionFormat') && tag.hasAttribute('username'))
     user = app.store.getBy('users', 'username', tag.getAttribute('username'));
-  else
+  else if (tag.hasAttribute('id'))
     user = app.store.getById('users', tag.getAttribute('id'));
 
   if (user) {

--- a/js/src/forum/utils/textFormatter.js
+++ b/js/src/forum/utils/textFormatter.js
@@ -2,10 +2,11 @@ import username from 'flarum/helpers/username';
 import extractText from 'flarum/utils/extractText';
 
 export function filterUserMentions(tag) {
-  const user = app.store.getBy('users', 'username', tag.getAttribute('username'));
+  const user = app.store.getById('users', tag.getAttribute('id'));
 
   if (user) {
     tag.setAttribute('id', user.id());
+    tag.setAttribute('slug', user.slug());
     tag.setAttribute('displayname', extractText(username(user)));
 
     return true;

--- a/js/src/forum/utils/textFormatter.js
+++ b/js/src/forum/utils/textFormatter.js
@@ -2,7 +2,12 @@ import username from 'flarum/helpers/username';
 import extractText from 'flarum/utils/extractText';
 
 export function filterUserMentions(tag) {
-  const user = app.store.getById('users', tag.getAttribute('id'));
+  let user;
+
+  if (tag.hasAttribute('username'))
+    user = app.store.getBy('users', 'username', tag.getAttribute('username'));
+  else
+    user = app.store.getById('users', tag.getAttribute('id'));
 
   if (user) {
     tag.setAttribute('id', user.id());

--- a/js/src/forum/utils/textFormatter.js
+++ b/js/src/forum/utils/textFormatter.js
@@ -11,6 +11,8 @@ export function filterUserMentions(tag) {
 
     return true;
   }
+
+  tag.invalidate();
 }
 
 export function filterPostMentions(tag) {

--- a/less/forum.less
+++ b/less/forum.less
@@ -4,6 +4,7 @@
   border-radius: @border-radius;
   padding: 2px 5px;
   border: 0 !important;
+  font-weight: 600;
 
   blockquote & {
     background: @body-bg;
@@ -11,6 +12,12 @@
   &:hover,
   &:active {
     color: @link-color;
+  }
+}
+.UserMention {
+  &--deleted {
+    opacity: 0.8;
+    filter: grayscale(1);
   }
 }
 .PostMention {

--- a/less/forum.less
+++ b/less/forum.less
@@ -14,7 +14,7 @@
     color: @link-color;
   }
 }
-.UserMention {
+.UserMention, .PostMention {
   &--deleted {
     opacity: 0.8;
     filter: grayscale(1);

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -4,6 +4,13 @@ flarum-mentions:
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
+  # Translations in this namespace are used by the admin interface.
+  admin:
+
+    # These translations are used in the mentions Settings page.
+    settings:
+      allow_username_format: Allow username mention format
+
   # Translations in this namespace are used by the forum user interface.
   forum:
 

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -36,6 +36,10 @@ flarum-mentions:
     user:
       mentions_link: Mentions
 
+    # These translations are used in the post mentions
+    post_mention:
+      unknown_text: "[unknown]"
+
   # Translations in this namespace are used in emails sent by the forum.
   email:
 

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -9,7 +9,10 @@ flarum-mentions:
 
     # These translations are used in the mentions Settings page.
     settings:
-      allow_username_format: Allow username mention format
+      allow_username_format_label: Allow username mention format (@Username)
+      allow_username_format_text: |
+        The current format for user mentions is @"Display Name"#ID.
+        This setting allows using the old format of @Username, however it will still be converted to the new format upon saving.
 
   # Translations in this namespace are used by the forum user interface.
   forum:

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -48,7 +48,7 @@ flarum-mentions:
 
     # These translations are used in the post mentions
     post_mention:
-      unknown_text: "[unknown]"
+      deleted_text: "[unknown]"
 
   # Translations in this namespace are used in emails sent by the forum.
   email:

--- a/migrations/2021_04_19_000000_set_default_settings.php
+++ b/migrations/2021_04_19_000000_set_default_settings.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+
+return Migration::addSettings([
+    'flarum-mentions.allow_username_format' => 1,
+]);

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -47,7 +47,15 @@ class ConfigureMentions
         $tag->attributes->add('slug');
         $tag->attributes->add('id')->filterChain->append('#uint');
 
-        $tag->template = '<a href="{$PROFILE_URL}{@slug}" class="UserMention">@<xsl:value-of select="@displayname"/></a>';
+        $tag->template = '
+            <xsl:choose>
+                <xsl:when test="@slug != \'\'">
+                    <a href="{$PROFILE_URL}{@slug}" class="UserMention">@<xsl:value-of select="@displayname"/></a>
+                </xsl:when>
+                <xsl:otherwise>
+                    <span class="UserMention UserMention--deleted">@<xsl:value-of select="@displayname"/></span>
+                </xsl:otherwise>
+            </xsl:choose>';
         $tag->filterChain->prepend([static::class, 'addUserId'])
             ->setJS('function(tag) { return flarum.extensions["flarum-mentions"].filterUserMentions(tag); }');
 

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -53,7 +53,7 @@ class ConfigureMentions
 
         $tag->template = '
             <xsl:choose>
-                <xsl:when test="@slug != \'\'">
+                <xsl:when test="@deleted != 1">
                     <a href="{$PROFILE_URL}{@slug}" class="UserMention">@<xsl:value-of select="@displayname"/></a>
                 </xsl:when>
                 <xsl:otherwise>

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -73,6 +73,8 @@ class ConfigureMentions
 
             return true;
         }
+
+        $tag->invalidate();
     }
 
     private function configurePostMentions(Configurator $config)

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -73,8 +73,9 @@ class ConfigureMentions
      */
     public static function addUserId($tag)
     {
-        if (! self::$slugManager)
+        if (! self::$slugManager) {
             self::$slugManager = resolve(SlugManager::class);
+        }
 
         if ($user = User::find($tag->getAttribute('id'))) {
             $tag->setAttribute('id', $user->id);

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -91,7 +91,15 @@ class ConfigureMentions
         $tag->attributes->add('discussionid')->filterChain->append('#uint');
         $tag->attributes->add('id')->filterChain->append('#uint');
 
-        $tag->template = '<a href="{$DISCUSSION_URL}{@discussionid}/{@number}" class="PostMention" data-id="{@id}"><xsl:value-of select="@displayname"/></a>';
+        $tag->template = '
+            <xsl:choose>
+                <xsl:when test="@deleted != 1">
+                    <a href="{$DISCUSSION_URL}{@discussionid}/{@number}" class="PostMention" data-id="{@id}"><xsl:value-of select="@displayname"/></a>
+                </xsl:when>
+                <xsl:otherwise>
+                    <span class="PostMention PostMention--deleted" data-id="{@id}"><xsl:value-of select="@displayname"/></span>
+                </xsl:otherwise>
+            </xsl:choose>';
 
         $tag->filterChain
             ->prepend([static::class, 'addPostId'])

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -86,7 +86,6 @@ class ConfigureMentions
 
         $tag = $config->tags->add($tagName);
 
-        $tag->attributes->add('username');
         $tag->attributes->add('displayname');
         $tag->attributes->add('number')->filterChain->append('#uint');
         $tag->attributes->add('discussionid')->filterChain->append('#uint');
@@ -98,7 +97,7 @@ class ConfigureMentions
             ->prepend([static::class, 'addPostId'])
             ->setJS('function(tag) { return flarum.extensions["flarum-mentions"].filterPostMentions(tag); }');
 
-        $config->Preg->match('/\B@(?<username>[a-z0-9_-]+)#(?<id>\d+)/i', $tagName);
+        $config->Preg->match('/\B@"(?<displayname>((?!"#[a-z]*[0-9]+).)+)"#p(?<id>[0-9]+)\b/i', $tagName);
     }
 
     /**

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -59,7 +59,7 @@ class ConfigureMentions
         $tag->filterChain->prepend([static::class, 'addUserId'])
             ->setJS('function(tag) { return flarum.extensions["flarum-mentions"].filterUserMentions(tag); }');
 
-        $config->Preg->match('/\B@"(?<displayname>((?!"#[a-z]*[0-9]+).)+)"#(?<id>[0-9]+)\b/i', $tagName);
+        $config->Preg->match('/\B@"(?<displayname>((?!"#[a-z]{0,3}[0-9]+).)+)"#(?<id>[0-9]+)\b/', $tagName);
     }
 
     /**
@@ -105,7 +105,7 @@ class ConfigureMentions
             ->prepend([static::class, 'addPostId'])
             ->setJS('function(tag) { return flarum.extensions["flarum-mentions"].filterPostMentions(tag); }');
 
-        $config->Preg->match('/\B@"(?<displayname>((?!"#[a-z]*[0-9]+).)+)"#p(?<id>[0-9]+)\b/i', $tagName);
+        $config->Preg->match('/\B@"(?<displayname>((?!"#[a-z]{0,3}[0-9]+).)+)"#p(?<id>[0-9]+)\b/', $tagName);
     }
 
     /**

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -49,7 +49,6 @@ class ConfigureMentions
 
         $tag = $config->tags->add($tagName);
         $tag->attributes->add('displayname');
-        $tag->attributes->add('slug');
         $tag->attributes->add('id')->filterChain->append('#uint');
 
         $tag->template = '

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -18,6 +18,11 @@ use s9e\TextFormatter\Configurator;
 class ConfigureMentions
 {
     /**
+     * @var SlugManager
+     */
+    protected static $slugManager;
+
+    /**
      * @var UrlGenerator
      */
     protected $url;
@@ -69,9 +74,12 @@ class ConfigureMentions
      */
     public static function addUserId($tag)
     {
+        if (! self::$slugManager)
+            self::$slugManager = resolve(SlugManager::class);
+
         if ($user = User::find($tag->getAttribute('id'))) {
             $tag->setAttribute('id', $user->id);
-            $tag->setAttribute('slug', resolve(SlugManager::class)->forResource(User::class)->toSlug($user));
+            $tag->setAttribute('slug', self::$slugManager->forResource(User::class)->toSlug($user));
             $tag->setAttribute('displayname', $user->display_name);
 
             return true;

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Mentions;
 
-use Flarum\Http\SlugManager;
 use Flarum\Http\UrlGenerator;
 use Flarum\Post\CommentPost;
 use Flarum\User\User;
@@ -17,11 +16,6 @@ use s9e\TextFormatter\Configurator;
 
 class ConfigureMentions
 {
-    /**
-     * @var SlugManager
-     */
-    protected static $slugManager;
-
     /**
      * @var UrlGenerator
      */
@@ -73,13 +67,8 @@ class ConfigureMentions
      */
     public static function addUserId($tag)
     {
-        if (! self::$slugManager) {
-            self::$slugManager = resolve(SlugManager::class);
-        }
-
         if ($user = User::find($tag->getAttribute('id'))) {
             $tag->setAttribute('id', $user->id);
-            $tag->setAttribute('slug', self::$slugManager->forResource(User::class)->toSlug($user));
             $tag->setAttribute('displayname', $user->display_name);
 
             return true;

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -44,7 +44,7 @@ class ConfigureMentions
 
     private function configureUserMentions(Configurator $config)
     {
-        $allow_username_format = $this->settings->get('flarum-mentions.allow_username_format');
+        $allow_username_format = (bool) $this->settings->get('flarum-mentions.allow_username_format');
 
         $config->rendering->parameters['PROFILE_URL'] = $this->url->to('forum')->route('user', ['username' => '']);
 

--- a/src/Formatter/FormatPostMentions.php
+++ b/src/Formatter/FormatPostMentions.php
@@ -12,9 +12,20 @@ namespace Flarum\Mentions\Formatter;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use s9e\TextFormatter\Renderer;
 use s9e\TextFormatter\Utils;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FormatPostMentions
 {
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     /**
      * Configure rendering for post mentions.
      *
@@ -32,6 +43,17 @@ class FormatPostMentions
             $post = $post->mentionsPosts->find($attributes['id']);
             if ($post && $post->user) {
                 $attributes['displayname'] = $post->user->display_name;
+            }
+
+            $attributes['deleted'] = false;
+
+            if (! $post) {
+                $attributes['displayname'] = $this->translator->trans('flarum-mentions.forum.post_mention.unknown_text');
+                $attributes['deleted'] = true;
+            }
+
+            if ($post && ! $post->user) {
+                $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }
 
             return $attributes;

--- a/src/Formatter/FormatPostMentions.php
+++ b/src/Formatter/FormatPostMentions.php
@@ -48,7 +48,7 @@ class FormatPostMentions
             $attributes['deleted'] = false;
 
             if (! $post) {
-                $attributes['displayname'] = $this->translator->trans('flarum-mentions.forum.post_mention.unknown_text');
+                $attributes['displayname'] = $this->translator->trans('flarum-mentions.forum.post_mention.deleted_text');
                 $attributes['deleted'] = true;
             }
 

--- a/src/Formatter/FormatUserMentions.php
+++ b/src/Formatter/FormatUserMentions.php
@@ -48,10 +48,13 @@ class FormatUserMentions
         return Utils::replaceAttributes($xml, 'USERMENTION', function ($attributes) use ($post) {
             $user = $post->mentionsUsers->find($attributes['id']);
 
+            $attributes['deleted'] = false;
+
             if ($user) {
                 $attributes['slug'] = $this->slugManager->forResource(User::class)->toSlug($user);
                 $attributes['displayname'] = $user->display_name;
             } else {
+                $attributes['deleted'] = true;
                 $attributes['slug'] = '';
                 $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }

--- a/src/Formatter/FormatUserMentions.php
+++ b/src/Formatter/FormatUserMentions.php
@@ -13,6 +13,7 @@ use Flarum\Http\SlugManager;
 use Flarum\User\User;
 use s9e\TextFormatter\Renderer;
 use s9e\TextFormatter\Utils;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FormatUserMentions
 {
@@ -21,9 +22,15 @@ class FormatUserMentions
      */
     private $slugManager;
 
-    public function __construct(SlugManager $slugManager)
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(SlugManager $slugManager, TranslatorInterface $translator)
     {
         $this->slugManager = $slugManager;
+        $this->translator = $translator;
     }
 
     /**
@@ -44,6 +51,9 @@ class FormatUserMentions
             if ($user) {
                 $attributes['slug'] = $this->slugManager->forResource(User::class)->toSlug($user);
                 $attributes['displayname'] = $user->display_name;
+            } else {
+                $attributes['slug'] = "";
+                $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }
 
             return $attributes;

--- a/src/Formatter/FormatUserMentions.php
+++ b/src/Formatter/FormatUserMentions.php
@@ -52,7 +52,7 @@ class FormatUserMentions
                 $attributes['slug'] = $this->slugManager->forResource(User::class)->toSlug($user);
                 $attributes['displayname'] = $user->display_name;
             } else {
-                $attributes['slug'] = "";
+                $attributes['slug'] = '';
                 $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }
 

--- a/src/Formatter/UnparsePostMentions.php
+++ b/src/Formatter/UnparsePostMentions.php
@@ -57,6 +57,10 @@ class UnparsePostMentions
                 $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }
 
+            if (strpos($attributes['displayname'], '"#') !== false) {
+                $attributes['displayname'] = preg_replace('/"#[a-z]{0,3}[0-9]+/', '_', $attributes['displayname']);
+            }
+
             return $attributes;
         });
     }

--- a/src/Formatter/UnparsePostMentions.php
+++ b/src/Formatter/UnparsePostMentions.php
@@ -34,12 +34,19 @@ class UnparsePostMentions
     public function __invoke($context, string $xml)
     {
         $xml = $this->updatePostMentionTags($context, $xml);
-        $xml = $this->removePostMentionTags($xml);
+        $xml = $this->unparsePostMentionTags($xml);
 
         return $xml;
     }
 
-    protected function updatePostMentionTags($context, string $xml)
+    /**
+     * Updates XML post mention tags before unparsing so that unparsing uses new display names.
+     *
+     * @param mixed $context
+     * @param string $xml : Parsed text.
+     * @return string $xml : Updated XML tags;
+     */
+    protected function updatePostMentionTags($context, string $xml): string
     {
         $post = $context;
 
@@ -65,7 +72,13 @@ class UnparsePostMentions
         });
     }
 
-    protected function removePostMentionTags(string $xml)
+    /**
+     * Transforms post mention tags from XML to raw unparsed content with updated format and display name.
+     *
+     * @param string $xml : Parsed text.
+     * @return string : Unparsed text.
+     */
+    protected function unparsePostMentionTags(string $xml): string
     {
         $tagName = 'POSTMENTION';
 

--- a/src/Formatter/UnparsePostMentions.php
+++ b/src/Formatter/UnparsePostMentions.php
@@ -12,9 +12,20 @@ namespace Flarum\Mentions\Formatter;
 use Flarum\Post\CommentPost;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use s9e\TextFormatter\Utils;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class UnparsePostMentions
 {
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     /**
      * Configure rendering for user mentions.
      *
@@ -38,6 +49,14 @@ class UnparsePostMentions
             $post = $post->mentionsPosts->find($attributes['id']);
             if ($post && $post->user) {
                 $attributes['displayname'] = $post->user->display_name;
+            }
+
+            if (! $post) {
+                $attributes['displayname'] = $this->translator->trans('flarum-mentions.forum.post_mention.unknown_text');
+            }
+
+            if ($post && ! $post->user) {
+                $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }
 
             return $attributes;

--- a/src/Formatter/UnparsePostMentions.php
+++ b/src/Formatter/UnparsePostMentions.php
@@ -9,8 +9,6 @@
 
 namespace Flarum\Mentions\Formatter;
 
-use Flarum\Post\CommentPost;
-use Psr\Http\Message\ServerRequestInterface as Request;
 use s9e\TextFormatter\Utils;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -72,7 +70,7 @@ class UnparsePostMentions
         }
 
         return preg_replace(
-            '/<' . preg_quote($tagName) . '\b[^>]*(?=\bdisplayname="(.*)")[^>]*(?=\bid="([0-9]+)")[^>]*>@[^<]+<\/' . preg_quote($tagName) . '>/U',
+            '/<'.preg_quote($tagName).'\b[^>]*(?=\bdisplayname="(.*)")[^>]*(?=\bid="([0-9]+)")[^>]*>@[^<]+<\/'.preg_quote($tagName).'>/U',
             '@"$1"#p$2',
             $xml
         );

--- a/src/Formatter/UnparsePostMentions.php
+++ b/src/Formatter/UnparsePostMentions.php
@@ -50,7 +50,7 @@ class UnparsePostMentions
             }
 
             if (! $post) {
-                $attributes['displayname'] = $this->translator->trans('flarum-mentions.forum.post_mention.unknown_text');
+                $attributes['displayname'] = $this->translator->trans('flarum-mentions.forum.post_mention.deleted_text');
             }
 
             if ($post && ! $post->user) {

--- a/src/Formatter/UnparsePostMentions.php
+++ b/src/Formatter/UnparsePostMentions.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Mentions\Formatter;
+
+use Flarum\Post\CommentPost;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use s9e\TextFormatter\Utils;
+
+class UnparsePostMentions
+{
+    /**
+     * Configure rendering for user mentions.
+     *
+     * @param string $xml
+     * @param mixed $context
+     * @return string $xml to be unparsed
+     */
+    public function __invoke($context, string $xml)
+    {
+        $xml = $this->updatePostMentionTags($context, $xml);
+        $xml = $this->removePostMentionTags($xml);
+
+        return $xml;
+    }
+
+    protected function updatePostMentionTags($context, string $xml)
+    {
+        $post = $context;
+
+        return Utils::replaceAttributes($xml, 'POSTMENTION', function ($attributes) use ($post) {
+            $post = $post->mentionsPosts->find($attributes['id']);
+            if ($post && $post->user) {
+                $attributes['displayname'] = $post->user->display_name;
+            }
+
+            return $attributes;
+        });
+    }
+
+    protected function removePostMentionTags(string $xml)
+    {
+        $tagName = 'POSTMENTION';
+
+        if (strpos($xml, $tagName) === false) {
+            return $xml;
+        }
+
+        return preg_replace(
+            '/<' . preg_quote($tagName) . '\b[^>]*(?=\bdisplayname="(.*)")[^>]*(?=\bid="([0-9]+)")[^>]*>@[^<]+<\/' . preg_quote($tagName) . '>/U',
+            '@"$1"#p$2',
+            $xml
+        );
+    }
+}

--- a/src/Formatter/UnparseUserMentions.php
+++ b/src/Formatter/UnparseUserMentions.php
@@ -54,10 +54,13 @@ class UnparseUserMentions
         return Utils::replaceAttributes($xml, 'USERMENTION', function ($attributes) use ($post) {
             $user = $post->mentionsUsers->find($attributes['id']);
 
+            $attributes['deleted'] = false;
+
             if ($user) {
                 $attributes['slug'] = $this->slugManager->forResource(User::class)->toSlug($user);
                 $attributes['displayname'] = $user->display_name;
             } else {
+                $attributes['deleted'] = true;
                 $attributes['slug'] = '';
                 $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }

--- a/src/Formatter/UnparseUserMentions.php
+++ b/src/Formatter/UnparseUserMentions.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Mentions\Formatter;
 
-use Flarum\Http\SlugManager;
 use Flarum\User\User;
 use s9e\TextFormatter\Utils;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -17,18 +16,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class UnparseUserMentions
 {
     /**
-     * @var SlugManager
-     */
-    private $slugManager;
-
-    /**
      * @var TranslatorInterface
      */
     private $translator;
 
-    public function __construct(SlugManager $slugManager, TranslatorInterface $translator)
+    public function __construct(TranslatorInterface $translator)
     {
-        $this->slugManager = $slugManager;
         $this->translator = $translator;
     }
 
@@ -57,11 +50,9 @@ class UnparseUserMentions
             $attributes['deleted'] = false;
 
             if ($user) {
-                $attributes['slug'] = $this->slugManager->forResource(User::class)->toSlug($user);
                 $attributes['displayname'] = $user->display_name;
             } else {
                 $attributes['deleted'] = true;
-                $attributes['slug'] = '';
                 $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }
 

--- a/src/Formatter/UnparseUserMentions.php
+++ b/src/Formatter/UnparseUserMentions.php
@@ -62,6 +62,10 @@ class UnparseUserMentions
                 $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }
 
+            if (strpos($attributes['displayname'], '"#') !== false) {
+                $attributes['displayname'] = preg_replace('/"#[a-z]{0,3}[0-9]+/', '_', $attributes['displayname']);
+            }
+
             return $attributes;
         });
     }

--- a/src/Formatter/UnparseUserMentions.php
+++ b/src/Formatter/UnparseUserMentions.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use s9e\TextFormatter\Parser;
 use s9e\TextFormatter\Renderer;
 use s9e\TextFormatter\Utils;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class UnparseUserMentions
 {
@@ -23,9 +24,15 @@ class UnparseUserMentions
      */
     private $slugManager;
 
-    public function __construct(SlugManager $slugManager)
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(SlugManager $slugManager, TranslatorInterface $translator)
     {
         $this->slugManager = $slugManager;
+        $this->translator = $translator;
     }
 
     /**
@@ -53,6 +60,9 @@ class UnparseUserMentions
             if ($user) {
                 $attributes['slug'] = $this->slugManager->forResource(User::class)->toSlug($user);
                 $attributes['displayname'] = $user->display_name;
+            } else {
+                $attributes['slug'] = "";
+                $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }
 
             return $attributes;

--- a/src/Formatter/UnparseUserMentions.php
+++ b/src/Formatter/UnparseUserMentions.php
@@ -11,9 +11,6 @@ namespace Flarum\Mentions\Formatter;
 
 use Flarum\Http\SlugManager;
 use Flarum\User\User;
-use Psr\Http\Message\ServerRequestInterface as Request;
-use s9e\TextFormatter\Parser;
-use s9e\TextFormatter\Renderer;
 use s9e\TextFormatter\Utils;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -61,7 +58,7 @@ class UnparseUserMentions
                 $attributes['slug'] = $this->slugManager->forResource(User::class)->toSlug($user);
                 $attributes['displayname'] = $user->display_name;
             } else {
-                $attributes['slug'] = "";
+                $attributes['slug'] = '';
                 $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }
 
@@ -78,7 +75,7 @@ class UnparseUserMentions
         }
 
         return preg_replace(
-            '/<' . preg_quote($tagName) . '\b[^>]*(?=\bdisplayname="(.*)")[^>]*(?=\bid="([0-9]+)")[^>]*>@[^<]+<\/' . preg_quote($tagName) . '>/U',
+            '/<'.preg_quote($tagName).'\b[^>]*(?=\bdisplayname="(.*)")[^>]*(?=\bid="([0-9]+)")[^>]*>@[^<]+<\/'.preg_quote($tagName).'>/U',
             '@"$1"#$2',
             $xml
         );

--- a/src/Formatter/UnparseUserMentions.php
+++ b/src/Formatter/UnparseUserMentions.php
@@ -39,6 +39,7 @@ class UnparseUserMentions
 
         return $xml;
     }
+
     /**
      * Updates XML user mention tags before unparsing so that unparsing uses new display names.
      *

--- a/src/Formatter/UnparseUserMentions.php
+++ b/src/Formatter/UnparseUserMentions.php
@@ -47,12 +47,9 @@ class UnparseUserMentions
         return Utils::replaceAttributes($xml, 'USERMENTION', function ($attributes) use ($post) {
             $user = $post->mentionsUsers->find($attributes['id']);
 
-            $attributes['deleted'] = false;
-
             if ($user) {
                 $attributes['displayname'] = $user->display_name;
             } else {
-                $attributes['deleted'] = true;
                 $attributes['displayname'] = $this->translator->trans('core.lib.username.deleted_text');
             }
 

--- a/src/Formatter/UnparseUserMentions.php
+++ b/src/Formatter/UnparseUserMentions.php
@@ -35,12 +35,18 @@ class UnparseUserMentions
     public function __invoke($context, string $xml)
     {
         $xml = $this->updateUserMentionTags($context, $xml);
-        $xml = $this->removeUserMentionTags($xml);
+        $xml = $this->unparseUserMentionTags($xml);
 
         return $xml;
     }
-
-    protected function updateUserMentionTags($context, string $xml)
+    /**
+     * Updates XML user mention tags before unparsing so that unparsing uses new display names.
+     *
+     * @param mixed $context
+     * @param string $xml : Parsed text.
+     * @return string $xml : Updated XML tags;
+     */
+    protected function updateUserMentionTags($context, string $xml): string
     {
         $post = $context;
 
@@ -61,7 +67,13 @@ class UnparseUserMentions
         });
     }
 
-    protected function removeUserMentionTags(string $xml)
+    /**
+     * Transforms user mention tags from XML to raw unparsed content with updated format and display name.
+     *
+     * @param string $xml : Parsed text.
+     * @return string : Unparsed text.
+     */
+    protected function unparseUserMentionTags(string $xml): string
     {
         $tagName = 'USERMENTION';
 

--- a/tests/integration/api/PostMentionsTest.php
+++ b/tests/integration/api/PostMentionsTest.php
@@ -36,6 +36,7 @@ class PostMentionsTest extends TestCase
             'users' => [
                 ['id' => 3, 'username' => 'potato', 'email' => 'potato@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 4, 'username' => 'toby', 'email' => 'toby@machine.local', 'is_email_confirmed' => 1],
+                ['id' => 5, 'username' => 'bad_user', 'email' => 'bad_user@machine.local', 'is_email_confirmed' => 1],
             ],
             'discussions' => [
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 3, 'first_post_id' => 4, 'comment_count' => 2],
@@ -43,10 +44,17 @@ class PostMentionsTest extends TestCase
             'posts' => [
                 ['id' => 4, 'number' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'comment', 'content' => '<r><POSTMENTION displayname="TobyFlarum___" id="5" number="2" discussionid="2" username="toby">@tobyuuu#5</POSTMENTION></r>'],
                 ['id' => 5, 'number' => 3, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 4, 'type' => 'comment', 'content' => '<r><POSTMENTION displayname="potato" id="4" number="3" discussionid="2" username="potato">@potato#4</POSTMENTION></r>'],
+                ['id' => 6, 'number' => 4, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'comment', 'content' => '<r><POSTMENTION displayname="i_am_a_deleted_user" id="7" number="5" discussionid="2" username="i_am_a_deleted_user">@"i_am_a_deleted_user"#p7</POSTMENTION></r>'],
+                ['id' => 7, 'number' => 5, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 2021, 'type' => 'comment', 'content' => '<r><POSTMENTION displayname="POTATO$" id="2010" number="7" discussionid="2">@"POTATO$"#2010</POSTMENTION></r>'],
+                ['id' => 8, 'number' => 6, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 4, 'type' => 'comment', 'content' => '<r><POSTMENTION displayname="i_am_a_deleted_user" id="2020" number="8" discussionid="2" username="i_am_a_deleted_user">@"i_am_a_deleted_user"#p2020</POSTMENTION></r>'],
+                ['id' => 9, 'number' => 10, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 5, 'type' => 'comment', 'content' => '<r><p>I am bad</p></r>'],
+                ['id' => 10, 'number' => 11, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 4, 'type' => 'comment', 'content' => '<r><POSTMENTION displayname="Bad &quot;#p6 User" id="9" number="10" discussionid="2">@"Bad "#p6 User"#p9</POSTMENTION></r>'],
             ],
             'post_mentions_post' => [
                 ['post_id' => 4, 'mentions_post_id' => 5],
-                ['post_id' => 5, 'mentions_post_id' => 4]
+                ['post_id' => 5, 'mentions_post_id' => 4],
+                ['post_id' => 6, 'mentions_post_id' => 7],
+                ['post_id' => 10, 'mentions_post_id' => 9]
             ],
             'settings' => [
                 ['key' => 'display_name_driver', 'value' => 'custom_display_name_driver'],
@@ -73,7 +81,7 @@ class PostMentionsTest extends TestCase
     /**
      * @test
      */
-    public function mentioning_a_valid_post_works()
+    public function mentioning_a_valid_post_with_old_format_doesnt_work()
     {
         $this->app();
         $this->recalculateDisplayNameDriver();
@@ -98,8 +106,42 @@ class PostMentionsTest extends TestCase
 
         $response = json_decode($response->getBody(), true);
 
+        $this->assertStringNotContainsString('POTATO$', $response['data']['attributes']['contentHtml']);
+        $this->assertEquals('@potato#4', $response['data']['attributes']['content']);
+        $this->assertStringNotContainsString('PostMention', $response['data']['attributes']['contentHtml']);
+        $this->assertNull(CommentPost::find($response['data']['id'])->mentionsPosts->find(4));
+    }
+
+    /**
+     * @test
+     */
+    public function mentioning_a_valid_post_with_new_format_works()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+
+        $response = $this->send(
+            $this->request('POST', '/api/posts', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => '@"POTATO$"#p4',
+                        ],
+                        'relationships' => [
+                            'discussion' => ['data' => ['id' => 2]],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
         $this->assertStringContainsString('POTATO$', $response['data']['attributes']['contentHtml']);
-        $this->assertStringContainsString('@potato#4', $response['data']['attributes']['content']);
+        $this->assertEquals('@"POTATO$"#p4', $response['data']['attributes']['content']);
         $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
         $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsPosts->find(4));
     }
@@ -118,7 +160,7 @@ class PostMentionsTest extends TestCase
                 'json' => [
                     'data' => [
                         'attributes' => [
-                            'content' => '@franzofflarum#215',
+                            'content' => '@"franzofflarum"#p215',
                         ],
                         'relationships' => [
                             'discussion' => ['data' => ['id' => 2]],
@@ -133,7 +175,7 @@ class PostMentionsTest extends TestCase
         $response = json_decode($response->getBody(), true);
 
         $this->assertStringNotContainsString('FRANZOFFLARUM$', $response['data']['attributes']['contentHtml']);
-        $this->assertStringContainsString('@franzofflarum#215', $response['data']['attributes']['content']);
+        $this->assertEquals('@"franzofflarum"#p215', $response['data']['attributes']['content']);
         $this->assertStringNotContainsString('PostMention', $response['data']['attributes']['contentHtml']);
         $this->assertCount(0, CommentPost::find($response['data']['id'])->mentionsPosts);
     }
@@ -152,7 +194,7 @@ class PostMentionsTest extends TestCase
                 'json' => [
                     'data' => [
                         'attributes' => [
-                            'content' => '@toby#5 @flarum @franzofflarum#220 @potato @potato#4',
+                            'content' => '@"TOBY$"#p5 @"flarum"#2015 @"franzofflarum"#220 @"POTATO$"#3 @"POTATO$"#p4',
                         ],
                         'relationships' => [
                             'discussion' => ['data' => ['id' => 2]],
@@ -169,7 +211,7 @@ class PostMentionsTest extends TestCase
         $this->assertStringContainsString('TOBY$', $response['data']['attributes']['contentHtml']);
         $this->assertStringNotContainsString('FRANZOFFLARUM$', $response['data']['attributes']['contentHtml']);
         $this->assertStringContainsString('POTATO$', $response['data']['attributes']['contentHtml']);
-        $this->assertEquals('@toby#5 @flarum @franzofflarum#220 @potato @potato#4', $response['data']['attributes']['content']);
+        $this->assertEquals('@"TOBY$"#p5 @"flarum"#2015 @"franzofflarum"#220 @"POTATO$"#3 @"POTATO$"#p4', $response['data']['attributes']['content']);
         $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
         $this->assertCount(2, CommentPost::find($response['data']['id'])->mentionsPosts);
     }
@@ -196,12 +238,211 @@ class PostMentionsTest extends TestCase
         $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
         $this->assertCount(1, CommentPost::find($response['data']['id'])->mentionsPosts);
     }
+
+    /**
+     * @test
+     */
+    public function post_mentions_unparse_with_fresh_data()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts/4', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString('@"TOBY$"#p5', $response['data']['attributes']['content']);
+        $this->assertCount(1, CommentPost::find($response['data']['id'])->mentionsPosts);
+    }
+
+    /**
+     * @test
+     */
+    public function deleted_post_mentions_s_user_unparse_and_render_without_user_data()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+        $deleted_text = $this->app()->getContainer()->make('translator')->trans('core.lib.username.deleted_text');
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts/6', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString($deleted_text, $response['data']['attributes']['contentHtml']);
+        $this->assertStringContainsString('@"'.$deleted_text.'"#p7', $response['data']['attributes']['content']);
+        $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
+        $this->assertStringNotContainsString('i_am_a_deleted_user', $response['data']['attributes']['contentHtml']);
+        $this->assertStringNotContainsString('i_am_a_deleted_user', $response['data']['attributes']['content']);
+        $this->assertCount(1, CommentPost::find($response['data']['id'])->mentionsPosts);
+    }
+
+    /**
+     * @test
+     */
+    public function deleted_post_mentions_unparse_and_render_without_user_data()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+        $unknown_text = $this->app()->getContainer()->make('translator')->trans('flarum-mentions.forum.post_mention.unknown_text');
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts/7', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString($unknown_text, $response['data']['attributes']['contentHtml']);
+        $this->assertStringContainsString('@"'.$unknown_text.'"#p2010', $response['data']['attributes']['content']);
+        $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
+        $this->assertStringNotContainsString('POTATO$', $response['data']['attributes']['contentHtml']);
+        $this->assertStringNotContainsString('POTATO$', $response['data']['attributes']['content']);
+        $this->assertCount(0, CommentPost::find($response['data']['id'])->mentionsPosts);
+    }
+
+    /**
+     * @test
+     */
+    public function deleted_post_mentions_and_deleted_user_unparse_and_render_without_user_data()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+        $unknown_text = $this->app()->getContainer()->make('translator')->trans('flarum-mentions.forum.post_mention.unknown_text');
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts/8', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString($unknown_text, $response['data']['attributes']['contentHtml']);
+        $this->assertStringContainsString('@"'.$unknown_text.'"#p2020', $response['data']['attributes']['content']);
+        $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
+        $this->assertStringNotContainsString('POTATO$', $response['data']['attributes']['contentHtml']);
+        $this->assertStringNotContainsString('POTATO$', $response['data']['attributes']['content']);
+        $this->assertCount(0, CommentPost::find($response['data']['id'])->mentionsPosts);
+    }
+
+    /**
+     * @test
+     */
+    public function post_mentions_with_unremoved_bad_string_from_display_names_doesnt_work()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+
+        $response = $this->send(
+            $this->request('POST', '/api/posts', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => '@"Bad "#p6 User"#p9',
+                        ],
+                        'relationships' => [
+                            'discussion' => ['data' => ['id' => 2]],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString('POTATO$', $response['data']['attributes']['contentHtml']);
+        $this->assertEquals('@"POTATO$"#p6 User"#p9', $response['data']['attributes']['content']);
+        $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
+        $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsPosts->find(6));
+    }
+
+    /**
+     * @test
+     */
+    public function post_mentions_unparsing_removes_bad_display_name_string()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts/10', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString('Bad "#p6 User', $response['data']['attributes']['contentHtml']);
+        $this->assertStringContainsString('@"Bad _ User"#p9', $response['data']['attributes']['content']);
+        $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
+        $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsPosts->find(9));
+    }
+
+    /**
+     * @test
+     */
+    public function post_mentions_with_removed_bad_string_from_display_names_works()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+
+        $response = $this->send(
+            $this->request('POST', '/api/posts', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => '@"Bad _ User"#p9',
+                        ],
+                        'relationships' => [
+                            'discussion' => ['data' => ['id' => 2]],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString('Bad "#p6 User', $response['data']['attributes']['contentHtml']);
+        $this->assertEquals('@"Bad _ User"#p9', $response['data']['attributes']['content']);
+        $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
+        $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsPosts->find(9));
+    }
 }
 
 class CustomOtherDisplayNameDriver implements DriverInterface
 {
     public function displayName(User $user): string
     {
+        if ($user->username === 'bad_user') {
+            return 'Bad "#p6 User';
+        }
+
         return strtoupper($user->username).'$';
     }
 }

--- a/tests/integration/api/PostMentionsTest.php
+++ b/tests/integration/api/PostMentionsTest.php
@@ -295,7 +295,7 @@ class PostMentionsTest extends TestCase
     {
         $this->app();
         $this->recalculateDisplayNameDriver();
-        $unknown_text = $this->app()->getContainer()->make('translator')->trans('flarum-mentions.forum.post_mention.unknown_text');
+        $deleted_text = $this->app()->getContainer()->make('translator')->trans('flarum-mentions.forum.post_mention.deleted_text');
 
         $response = $this->send(
             $this->request('GET', '/api/posts/7', [
@@ -307,8 +307,8 @@ class PostMentionsTest extends TestCase
 
         $response = json_decode($response->getBody(), true);
 
-        $this->assertStringContainsString($unknown_text, $response['data']['attributes']['contentHtml']);
-        $this->assertStringContainsString('@"'.$unknown_text.'"#p2010', $response['data']['attributes']['content']);
+        $this->assertStringContainsString($deleted_text, $response['data']['attributes']['contentHtml']);
+        $this->assertStringContainsString('@"'.$deleted_text.'"#p2010', $response['data']['attributes']['content']);
         $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
         $this->assertStringNotContainsString('POTATO$', $response['data']['attributes']['contentHtml']);
         $this->assertStringNotContainsString('POTATO$', $response['data']['attributes']['content']);
@@ -322,7 +322,7 @@ class PostMentionsTest extends TestCase
     {
         $this->app();
         $this->recalculateDisplayNameDriver();
-        $unknown_text = $this->app()->getContainer()->make('translator')->trans('flarum-mentions.forum.post_mention.unknown_text');
+        $deleted_text = $this->app()->getContainer()->make('translator')->trans('flarum-mentions.forum.post_mention.deleted_text');
 
         $response = $this->send(
             $this->request('GET', '/api/posts/8', [
@@ -334,8 +334,8 @@ class PostMentionsTest extends TestCase
 
         $response = json_decode($response->getBody(), true);
 
-        $this->assertStringContainsString($unknown_text, $response['data']['attributes']['contentHtml']);
-        $this->assertStringContainsString('@"'.$unknown_text.'"#p2020', $response['data']['attributes']['content']);
+        $this->assertStringContainsString($deleted_text, $response['data']['attributes']['contentHtml']);
+        $this->assertStringContainsString('@"'.$deleted_text.'"#p2020', $response['data']['attributes']['content']);
         $this->assertStringContainsString('PostMention', $response['data']['attributes']['contentHtml']);
         $this->assertStringNotContainsString('POTATO$', $response['data']['attributes']['contentHtml']);
         $this->assertStringNotContainsString('POTATO$', $response['data']['attributes']['content']);

--- a/tests/integration/api/UserMentionsTest.php
+++ b/tests/integration/api/UserMentionsTest.php
@@ -37,15 +37,19 @@ class UserMentionsTest extends TestCase
                 $this->normalUser(),
                 ['id' => 3, 'username' => 'potato', 'email' => 'potato@machine.local', 'is_email_confirmed' => 1],
                 ['id' => 4, 'username' => 'toby', 'email' => 'toby@machine.local', 'is_email_confirmed' => 1],
+                ['id' => 5, 'username' => 'bad_user', 'email' => 'bad_user@machine.local', 'is_email_confirmed' => 1],
             ],
             'discussions' => [
                 ['id' => 2, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 3, 'first_post_id' => 4, 'comment_count' => 2],
             ],
             'posts' => [
                 ['id' => 4, 'number' => 2, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 3, 'type' => 'comment', 'content' => '<r><USERMENTION displayname="TobyFlarum___" id="4" username="toby">@tobyuuu</USERMENTION></r>'],
+                ['id' => 6, 'number' => 3, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 4, 'type' => 'comment', 'content' => '<r><USERMENTION displayname="i_am_a_deleted_user" id="2021" username="i_am_a_deleted_user">@"i_am_a_deleted_user"#2021</USERMENTION></r>'],
+                ['id' => 10, 'number' => 11, 'discussion_id' => 2, 'created_at' => Carbon::now(), 'user_id' => 5, 'type' => 'comment', 'content' => '<r><USERMENTION displayname="Bad &quot;#p6 User" id="5">@"Bad "#p6 User"#5</USERMENTION></r>'],
             ],
             'post_mentions_user' => [
-                ['post_id' => 4, 'mentions_user_id' => 4]
+                ['post_id' => 4, 'mentions_user_id' => 4],
+                ['post_id' => 10, 'mentions_user_id' => 5]
             ],
             'settings' => [
                 ['key' => 'display_name_driver', 'value' => 'custom_display_name_driver'],
@@ -72,14 +76,14 @@ class UserMentionsTest extends TestCase
     /**
      * @test
      */
-    public function mentioning_a_valid_user_works()
+    public function mentioning_a_valid_user_with_old_format_doesnt_work()
     {
         $this->app();
         $this->recalculateDisplayNameDriver();
 
         $response = $this->send(
             $this->request('POST', '/api/posts', [
-                'authenticatedAs' => 2,
+                'authenticatedAs' => 1,
                 'json' => [
                     'data' => [
                         'attributes' => [
@@ -97,8 +101,42 @@ class UserMentionsTest extends TestCase
 
         $response = json_decode($response->getBody(), true);
 
-        $this->assertStringContainsString('@POTATO$', $response['data']['attributes']['contentHtml']);
+        $this->assertStringNotContainsString('@POTATO$', $response['data']['attributes']['contentHtml']);
         $this->assertStringContainsString('@potato', $response['data']['attributes']['content']);
+        $this->assertStringNotContainsString('UserMention', $response['data']['attributes']['contentHtml']);
+        $this->assertCount(0, CommentPost::find($response['data']['id'])->mentionsUsers);
+    }
+
+    /**
+     * @test
+     */
+    public function mentioning_a_valid_user_with_new_format_works()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+
+        $response = $this->send(
+            $this->request('POST', '/api/posts', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => '@"POTATO$"#3',
+                        ],
+                        'relationships' => [
+                            'discussion' => ['data' => ['id' => 2]],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString('@POTATO$', $response['data']['attributes']['contentHtml']);
+        $this->assertStringContainsString('@"POTATO$"#3', $response['data']['attributes']['content']);
         $this->assertStringContainsString('UserMention', $response['data']['attributes']['contentHtml']);
         $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsUsers->find(3));
     }
@@ -113,11 +151,11 @@ class UserMentionsTest extends TestCase
 
         $response = $this->send(
             $this->request('POST', '/api/posts', [
-                'authenticatedAs' => 2,
+                'authenticatedAs' => 1,
                 'json' => [
                     'data' => [
                         'attributes' => [
-                            'content' => '@franzofflarum',
+                            'content' => '@"franzofflarum"#82',
                         ],
                         'relationships' => [
                             'discussion' => ['data' => ['id' => 2]],
@@ -132,7 +170,7 @@ class UserMentionsTest extends TestCase
         $response = json_decode($response->getBody(), true);
 
         $this->assertStringNotContainsString('@FRANZOFFLARUM$', $response['data']['attributes']['contentHtml']);
-        $this->assertStringContainsString('@franzofflarum', $response['data']['attributes']['content']);
+        $this->assertStringContainsString('@"franzofflarum"#82', $response['data']['attributes']['content']);
         $this->assertStringNotContainsString('UserMention', $response['data']['attributes']['contentHtml']);
         $this->assertCount(0, CommentPost::find($response['data']['id'])->mentionsUsers);
     }
@@ -147,11 +185,11 @@ class UserMentionsTest extends TestCase
 
         $response = $this->send(
             $this->request('POST', '/api/posts', [
-                'authenticatedAs' => 2,
+                'authenticatedAs' => 1,
                 'json' => [
                     'data' => [
                         'attributes' => [
-                            'content' => '@toby @potato#4 @franzofflarum @potato',
+                            'content' => '@"TOBY$"#4 @"POTATO$"#p4 @"franzofflarum"#82 @"POTATO$"#3',
                         ],
                         'relationships' => [
                             'discussion' => ['data' => ['id' => 2]],
@@ -168,7 +206,7 @@ class UserMentionsTest extends TestCase
         $this->assertStringContainsString('@TOBY$', $response['data']['attributes']['contentHtml']);
         $this->assertStringNotContainsString('@FRANZOFFLARUM$', $response['data']['attributes']['contentHtml']);
         $this->assertStringContainsString('@POTATO$', $response['data']['attributes']['contentHtml']);
-        $this->assertEquals('@toby @potato#4 @franzofflarum @potato', $response['data']['attributes']['content']);
+        $this->assertEquals('@"TOBY$"#4 @"POTATO$"#p4 @"franzofflarum"#82 @"POTATO$"#3', $response['data']['attributes']['content']);
         $this->assertStringContainsString('UserMention', $response['data']['attributes']['contentHtml']);
         $this->assertCount(2, CommentPost::find($response['data']['id'])->mentionsUsers);
     }
@@ -176,7 +214,7 @@ class UserMentionsTest extends TestCase
     /**
      * @test
      */
-    public function user_mentions_render_with_fresh_data()
+    public function old_user_mentions_still_render()
     {
         $this->app();
         $this->recalculateDisplayNameDriver();
@@ -195,12 +233,201 @@ class UserMentionsTest extends TestCase
         $this->assertStringContainsString('UserMention', $response['data']['attributes']['contentHtml']);
         $this->assertCount(1, CommentPost::find($response['data']['id'])->mentionsUsers);
     }
+
+    /**
+     * @test
+     */
+    public function user_mentions_render_with_fresh_data()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+
+        $response = $this->send(
+            $this->request('POST', '/api/posts', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => '@"potato_"#3',
+                        ],
+                        'relationships' => [
+                            'discussion' => ['data' => ['id' => 2]],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString('@POTATO$', $response['data']['attributes']['contentHtml']);
+        $this->assertStringContainsString('UserMention', $response['data']['attributes']['contentHtml']);
+        $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsUsers->find(3));
+    }
+
+    /**
+     * @test
+     */
+    public function user_mentions_unparse_with_fresh_data()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+
+        $response = $this->send(
+            $this->request('POST', '/api/posts', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => '@"potato_"#3',
+                        ],
+                        'relationships' => [
+                            'discussion' => ['data' => ['id' => 2]],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString('@"POTATO$"#3', $response['data']['attributes']['content']);
+        $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsUsers->find(3));
+    }
+
+    /**
+     * @test
+     */
+    public function deleted_user_mentions_unparse_and_render_without_user_data()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+        $deleted_text = $this->app()->getContainer()->make('translator')->trans('core.lib.username.deleted_text');
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts/6', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString("@$deleted_text", $response['data']['attributes']['contentHtml']);
+        $this->assertStringContainsString('@"'.$deleted_text.'"#2021', $response['data']['attributes']['content']);
+        $this->assertStringContainsString('UserMention', $response['data']['attributes']['contentHtml']);
+        $this->assertStringContainsString('UserMention--deleted', $response['data']['attributes']['contentHtml']);
+        $this->assertStringNotContainsString('i_am_a_deleted_user', $response['data']['attributes']['contentHtml']);
+        $this->assertStringNotContainsString('i_am_a_deleted_user', $response['data']['attributes']['content']);
+        $this->assertCount(0, CommentPost::find($response['data']['id'])->mentionsUsers);
+    }
+
+    /**
+     * @test
+     */
+    public function user_mentions_with_unremoved_bad_string_from_display_names_doesnt_work()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+
+        $response = $this->send(
+            $this->request('POST', '/api/posts', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => '@"Bad "#p6 User"#5',
+                        ],
+                        'relationships' => [
+                            'discussion' => ['data' => ['id' => 2]],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringNotContainsString('Bad "#p6 User', $response['data']['attributes']['contentHtml']);
+        $this->assertNotEquals('@"Bad "#p6 User"#5', $response['data']['attributes']['content']);
+        $this->assertStringNotContainsString('UserMention', $response['data']['attributes']['contentHtml']);
+        $this->assertNull(CommentPost::find($response['data']['id'])->mentionsUsers->find(5));
+    }
+
+    /**
+     * @test
+     */
+    public function user_mentions_unparsing_removes_bad_display_name_string()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts/10', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString('Bad "#p6 User', $response['data']['attributes']['contentHtml']);
+        $this->assertStringContainsString('@"Bad _ User"#5', $response['data']['attributes']['content']);
+        $this->assertStringContainsString('UserMention', $response['data']['attributes']['contentHtml']);
+        $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsUsers->find(5));
+    }
+
+    /**
+     * @test
+     */
+    public function user_mentions_with_removed_bad_string_from_display_names_works()
+    {
+        $this->app();
+        $this->recalculateDisplayNameDriver();
+
+        $response = $this->send(
+            $this->request('POST', '/api/posts', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => '@"Bad _ User"#5',
+                        ],
+                        'relationships' => [
+                            'discussion' => ['data' => ['id' => 2]],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString('Bad "#p6 User', $response['data']['attributes']['contentHtml']);
+        $this->assertEquals('@"Bad _ User"#5', $response['data']['attributes']['content']);
+        $this->assertStringContainsString('UserMention', $response['data']['attributes']['contentHtml']);
+        $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsUsers->find(5));
+    }
 }
 
 class CustomDisplayNameDriver implements DriverInterface
 {
     public function displayName(User $user): string
     {
+        if ($user->username === 'bad_user') {
+            return 'Bad "#p6 User';
+        }
+
         return strtoupper($user->username).'$';
     }
 }


### PR DESCRIPTION
**Part of flarum/core#1734**
**Works with flarum/core#2780**

**Changes proposed in this pull request:**
* Changes the mentions format:
  + From `@Username` to `@"Display Name"#USER_ID` for user mentions.
  + From `@Username#POST_ID` to `@"Display Name"#pPOST_ID` for post mentions.
* Updates old formats and old mention data by hooking into the unparsing and rendering processes updating tags:
  1. For **unparsing** and **rendering** it first updates mention tags to hold newer data, for example `USERMENTION` tags containing old display names or slugs.
  2. For **unparsing** it then transforms mention tags to raw mention formats, for example: `<USERMENTION displayname="Display Name" id="ID">@Username</USERMENTION>` becomes `@"Display Name"#ID`.
  3. Step 1 above results in hiding deleted user information from both rendered content and parsed content.
* Removes occurences of `"#{letters}{numbers}` from display names (on autocomplete, on reply, on unparsing) as that can end up with either the mention not working or an unintended mention be rendered (for example `"#p90` or if an extension adds a new type of mentions like group mentions: `"#g51`).
* Adds minor styling to deleted user mentions and deleted post mentions, and turns them into `span` elements instead of links that take nowhere. Stops deleted post mentions from attempting to show a preview of the deleted post.
![flarum lan_d_152-double-the-cost4_3](https://user-images.githubusercontent.com/20267363/114702100-879fb280-9d1b-11eb-9c81-b67bed0821b4.png)


**Reviewers should focus on:**
* Code quality.
* Regular expressions:
  + https://regex101.com/r/Mk4Ojg/1
  + https://regex101.com/r/rR5Ngv/1
* Logic.

<summary>
<details>
<img src="https://user-images.githubusercontent.com/20267363/114701383-a6ea1000-9d1a-11eb-872b-928e803406c3.png" alt="user mentions debugging new format">
<img src="https://user-images.githubusercontent.com/20267363/114701414-b2d5d200-9d1a-11eb-9a63-3ae94c5a008a.png" alt="post mentions debugging new format">
</details>
</summary>

s9e\TextFormatter phases:
```
                Parsing 
              ↗         ↘
Original text             XML → Rendering → HTML
              ↖         ↙
               Unparsing
```

Flowchart giving a general idea on how an old mention format is handled (lifecycle)
![flarum-user-mentions-lifecycle](https://user-images.githubusercontent.com/20267363/114701086-42c74c00-9d1a-11eb-8c53-767163a7dac5.png)