### PR TITLE
Support smart quotes in mentions format

### DIFF
--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -76,7 +76,7 @@ export default function addComposerAutocomplete() {
 
         if (absMentionStart) {
           typed = lastChunk.substring(relMentionStart).toLowerCase();
-          matchTyped = typed.match(/^"((?:(?!"#).)+)$/);
+          matchTyped = typed.match(/^["|“]((?:(?!"#).)+)$/);
           typed = (matchTyped && matchTyped[1]) || typed;
 
           const makeSuggestion = function(user, replacement, content, className = '') {

--- a/src/ConfigureMentions.php
+++ b/src/ConfigureMentions.php
@@ -58,7 +58,7 @@ class ConfigureMentions
         $tag->filterChain->prepend([static::class, 'addUserId'])
             ->setJS('function(tag) { return flarum.extensions["flarum-mentions"].filterUserMentions(tag); }');
 
-        $config->Preg->match('/\B@"(?<displayname>((?!"#[a-z]{0,3}[0-9]+).)+)"#(?<id>[0-9]+)\b/', $tagName);
+        $config->Preg->match('/\B@["|“](?<displayname>((?!"#[a-z]{0,3}[0-9]+).)+)["|”]#(?<id>[0-9]+)\b/', $tagName);
         $config->Preg->match('/\B@(?<username>[a-z0-9_-]+)(?!#)/i', $tagName);
     }
 
@@ -114,7 +114,7 @@ class ConfigureMentions
             ->prepend([static::class, 'addPostId'])
             ->setJS('function(tag) { return flarum.extensions["flarum-mentions"].filterPostMentions(tag); }');
 
-        $config->Preg->match('/\B@"(?<displayname>((?!"#[a-z]{0,3}[0-9]+).)+)"#p(?<id>[0-9]+)\b/', $tagName);
+        $config->Preg->match('/\B@["|“](?<displayname>((?!"#[a-z]{0,3}[0-9]+).)+)["|”]#p(?<id>[0-9]+)\b/', $tagName);
     }
 
     /**

--- a/tests/integration/api/UserMentionsTest.php
+++ b/tests/integration/api/UserMentionsTest.php
@@ -159,6 +159,37 @@ class UserMentionsTest extends TestCase
     /**
      * @test
      */
+    public function mentioning_a_valid_user_with_new_format_with_smart_quotes_works()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/posts', [
+                'authenticatedAs' => 1,
+                'json' => [
+                    'data' => [
+                        'attributes' => [
+                            'content' => '@“POTATO$”#3',
+                        ],
+                        'relationships' => [
+                            'discussion' => ['data' => ['id' => 2]],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $response = json_decode($response->getBody(), true);
+
+        $this->assertStringContainsString('@POTATO$', $response['data']['attributes']['contentHtml']);
+        $this->assertStringContainsString('@"POTATO$"#3', $response['data']['attributes']['content']);
+        $this->assertStringContainsString('UserMention', $response['data']['attributes']['contentHtml']);
+        $this->assertNotNull(CommentPost::find($response['data']['id'])->mentionsUsers->find(3));
+    }
+
+    /**
+     * @test
+     */
     public function mentioning_an_invalid_user_doesnt_work()
     {
         $response = $this->send(

--- a/tests/integration/api/UserMentionsTest.php
+++ b/tests/integration/api/UserMentionsTest.php
@@ -159,7 +159,7 @@ class UserMentionsTest extends TestCase
     /**
      * @test
      */
-    public function mentioning_a_valid_user_with_new_format_with_smart_quotes_works()
+    public function mentioning_a_valid_user_with_new_format_with_smart_quotes_works_and_falls_back_to_normal_quotes()
     {
         $response = $this->send(
             $this->request('POST', '/api/posts', [


### PR DESCRIPTION
**Fixes flarum/core#2879**

Adds support for smart quotes in mentions format.

When testing don't forget to clear the cache first `php flarum cache:clear`.