### PR TITLE
Fix unrecognised user/post mentions

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -11,6 +11,7 @@ namespace Flarum\Mentions;
 
 use Flarum\Api\Controller;
 use Flarum\Api\Serializer\BasicPostSerializer;
+use Flarum\Api\Serializer\BasicUserSerializer;
 use Flarum\Api\Serializer\PostSerializer;
 use Flarum\Extend;
 use Flarum\Mentions\Notification\PostMentionedBlueprint;
@@ -56,7 +57,7 @@ return [
     (new Extend\ApiSerializer(BasicPostSerializer::class))
         ->hasMany('mentionedBy', BasicPostSerializer::class)
         ->hasMany('mentionsPosts', BasicPostSerializer::class)
-        ->hasMany('mentionsUsers', BasicPostSerializer::class),
+        ->hasMany('mentionsUsers', BasicUserSerializer::class),
 
     (new Extend\ApiController(Controller\ShowDiscussionController::class))
         ->addInclude(['posts.mentionedBy', 'posts.mentionedBy.user', 'posts.mentionedBy.discussion']),

--- a/src/Listener/UpdateMentionsMetadataWhenVisible.php
+++ b/src/Listener/UpdateMentionsMetadataWhenVisible.php
@@ -55,6 +55,7 @@ class UpdateMentionsMetadataWhenVisible
     protected function syncUserMentions(Post $post, array $mentioned)
     {
         $post->mentionsUsers()->sync($mentioned);
+        $post->unsetRelation('mentionsUsers');
 
         $users = User::whereIn('id', $mentioned)
             ->get()
@@ -69,6 +70,7 @@ class UpdateMentionsMetadataWhenVisible
     protected function syncPostMentions(Post $reply, array $mentioned)
     {
         $reply->mentionsPosts()->sync($mentioned);
+        $reply->unsetRelation('mentionsPosts');
 
         $posts = Post::with('user')
             ->whereIn('id', $mentioned)


### PR DESCRIPTION
**Fixes flarum/core#2989**

The reason this happens is because the modified relationship is not refreshed, so the formatter doesn't recognize the new mentions as valid, and the returned HTML content contains the unproperly rendered mentions.