### PR TITLE
Eager load more necessary related mentions

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -11,6 +11,7 @@ namespace Flarum\Mentions;
 
 use Flarum\Api\Controller;
 use Flarum\Api\Serializer\BasicPostSerializer;
+use Flarum\Api\Serializer\BasicUserSerializer;
 use Flarum\Api\Serializer\PostSerializer;
 use Flarum\Extend;
 use Flarum\Mentions\Notification\PostMentionedBlueprint;
@@ -56,19 +57,48 @@ return [
     (new Extend\ApiSerializer(BasicPostSerializer::class))
         ->hasMany('mentionedBy', BasicPostSerializer::class)
         ->hasMany('mentionsPosts', BasicPostSerializer::class)
-        ->hasMany('mentionsUsers', BasicPostSerializer::class),
+        ->hasMany('mentionsUsers', BasicUserSerializer::class),
 
     (new Extend\ApiController(Controller\ShowDiscussionController::class))
-        ->addInclude(['posts.mentionedBy', 'posts.mentionedBy.user', 'posts.mentionedBy.discussion']),
+        ->addInclude(['posts.mentionedBy', 'posts.mentionedBy.user', 'posts.mentionedBy.discussion'])
+        ->load([
+            'posts.mentionsUsers', 'posts.mentionsPosts', 'posts.mentionsPosts.user', 'posts.mentionedBy',
+            'posts.mentionedBy.mentionsPosts', 'posts.mentionedBy.mentionsPosts.user', 'posts.mentionedBy.mentionsUsers',
+        ]),
+
+    (new Extend\ApiController(Controller\ListDiscussionsController::class))
+        ->load([
+            'firstPost.mentionsUsers', 'firstPost.mentionsPosts', 'firstPost.mentionsPosts.user',
+            'lastPost.mentionsUsers', 'lastPost.mentionsPosts', 'lastPost.mentionsPosts.user'
+        ]),
 
     (new Extend\ApiController(Controller\ShowPostController::class))
-        ->addInclude(['mentionedBy', 'mentionedBy.user', 'mentionedBy.discussion']),
+        ->addInclude(['mentionedBy', 'mentionedBy.user', 'mentionedBy.discussion'])
+        ->load([
+            'mentionsUsers', 'mentionsPosts', 'mentionsPosts.user', 'mentionedBy',
+            'mentionedBy.mentionsPosts', 'mentionedBy.mentionsPosts.user', 'mentionedBy.mentionsUsers',
+        ]),
 
     (new Extend\ApiController(Controller\ListPostsController::class))
-        ->addInclude(['mentionedBy', 'mentionedBy.user', 'mentionedBy.discussion']),
+        ->addInclude(['mentionedBy', 'mentionedBy.user', 'mentionedBy.discussion'])
+        ->load([
+            'mentionsUsers', 'mentionsPosts', 'mentionsPosts.user', 'mentionedBy',
+            'mentionedBy.mentionsPosts', 'mentionedBy.mentionsPosts.user', 'mentionedBy.mentionsUsers',
+        ]),
 
     (new Extend\ApiController(Controller\CreatePostController::class))
-        ->addInclude(['mentionsPosts', 'mentionsPosts.mentionedBy']),
+        ->addInclude(['mentionsPosts', 'mentionsPosts.mentionedBy'])
+        ->load([
+            'mentionsUsers', 'mentionsPosts', 'mentionsPosts.user', 'mentionedBy',
+            'mentionedBy.mentionsPosts', 'mentionedBy.mentionsPosts.user', 'mentionedBy.mentionsUsers',
+        ]),
+
+    (new Extend\ApiController(Controller\UpdatePostController::class))
+        ->addInclude(['mentionsPosts', 'mentionsPosts.mentionedBy'])
+        ->load([
+            'mentionsUsers', 'mentionsPosts', 'mentionsPosts.user', 'mentionedBy',
+            'mentionedBy.mentionsPosts', 'mentionedBy.mentionsPosts.user', 'mentionedBy.mentionsUsers',
+        ]),
 
     (new Extend\ApiController(Controller\AbstractSerializeController::class))
         ->prepareDataForSerialization(FilterVisiblePosts::class),

--- a/extend.php
+++ b/extend.php
@@ -73,11 +73,7 @@ return [
         ]),
 
     (new Extend\ApiController(Controller\ShowPostController::class))
-        ->addInclude(['mentionedBy', 'mentionedBy.user', 'mentionedBy.discussion'])
-        ->load([
-            'mentionsUsers', 'mentionsPosts', 'mentionsPosts.user', 'mentionedBy',
-            'mentionedBy.mentionsPosts', 'mentionedBy.mentionsPosts.user', 'mentionedBy.mentionsUsers',
-        ]),
+        ->addInclude(['mentionedBy', 'mentionedBy.user', 'mentionedBy.discussion']),
 
     (new Extend\ApiController(Controller\ListPostsController::class))
         ->addInclude(['mentionedBy', 'mentionedBy.user', 'mentionedBy.discussion'])
@@ -87,18 +83,10 @@ return [
         ]),
 
     (new Extend\ApiController(Controller\CreatePostController::class))
-        ->addInclude(['mentionsPosts', 'mentionsPosts.mentionedBy'])
-        ->load([
-            'mentionsUsers', 'mentionsPosts', 'mentionsPosts.user', 'mentionedBy',
-            'mentionedBy.mentionsPosts', 'mentionedBy.mentionsPosts.user', 'mentionedBy.mentionsUsers',
-        ]),
+        ->addInclude(['mentionsPosts', 'mentionsPosts.mentionedBy']),
 
     (new Extend\ApiController(Controller\UpdatePostController::class))
-        ->addInclude(['mentionsPosts', 'mentionsPosts.mentionedBy'])
-        ->load([
-            'mentionsUsers', 'mentionsPosts', 'mentionsPosts.user', 'mentionedBy',
-            'mentionedBy.mentionsPosts', 'mentionedBy.mentionsPosts.user', 'mentionedBy.mentionsUsers',
-        ]),
+        ->addInclude(['mentionsPosts', 'mentionsPosts.mentionedBy']),
 
     (new Extend\ApiController(Controller\AbstractSerializeController::class))
         ->prepareDataForSerialization(FilterVisiblePosts::class),

--- a/src/FilterVisiblePosts.php
+++ b/src/FilterVisiblePosts.php
@@ -44,6 +44,8 @@ class FilterVisiblePosts
      */
     public function __invoke(Controller\AbstractSerializeController $controller, $data, ServerRequestInterface $request)
     {
+        $relations = [];
+
         // Firstly we gather a list of posts contained within the API document.
         // This will vary according to the API endpoint that is being accessed.
         if ($controller instanceof Controller\ShowDiscussionController) {
@@ -51,6 +53,11 @@ class FilterVisiblePosts
         } elseif ($controller instanceof Controller\ShowPostController
             || $controller instanceof Controller\CreatePostController
             || $controller instanceof Controller\UpdatePostController) {
+            $relations = [
+                'mentionsUsers', 'mentionsPosts', 'mentionsPosts.user', 'mentionedBy',
+                'mentionedBy.mentionsPosts', 'mentionedBy.mentionsPosts.user', 'mentionedBy.mentionsUsers'
+            ];
+
             $posts = [$data];
         } elseif ($controller instanceof Controller\ListPostsController) {
             $posts = $data;
@@ -63,6 +70,11 @@ class FilterVisiblePosts
             $posts = $posts->filter(function ($post) {
                 return $post instanceof CommentPost;
             });
+
+            // Load all of the users that these posts mention. This way the data
+            // will be ready to go when we need to sub in current usernames
+            // during the rendering process.
+            $posts->loadMissing($relations);
 
             // Construct a list of the IDs of all of the posts that these posts
             // have been mentioned in. We can then filter this list of IDs to

--- a/src/FilterVisiblePosts.php
+++ b/src/FilterVisiblePosts.php
@@ -64,11 +64,6 @@ class FilterVisiblePosts
                 return $post instanceof CommentPost;
             });
 
-            // Load all of the users that these posts mention. This way the data
-            // will be ready to go when we need to sub in current usernames
-            // during the rendering process.
-            $posts->loadMissing(['mentionsUsers', 'mentionsPosts.user', 'mentionedBy']);
-
             // Construct a list of the IDs of all of the posts that these posts
             // have been mentioned in. We can then filter this list of IDs to
             // weed out all of the ones which the user is not meant to see.


### PR DESCRIPTION
**Fixes flarum/core#3047**
**Relies on flarum/core#3048**

These missing relations caused more queries to be called, the more mentions posts have the more queries produced.

### `/api/discussions` endpoint
Before | After
-- | --
![Screenshot from 2021-08-23 14-19-01](https://user-images.githubusercontent.com/20267363/130471065-d293ff1d-6745-4863-ab0b-67b6e0c7e77f.png) | ![Screenshot from 2021-08-23 14-19-04](https://user-images.githubusercontent.com/20267363/130471140-ac2e9ae6-e373-4c81-9565-f0c7454f04be.png)

With all included relations (notably `firstPost,lastPost` containing post and user mentions)
Before | After
-- | --
![Screenshot from 2021-08-23 14-19-10](https://user-images.githubusercontent.com/20267363/130471391-dbeeffab-df46-4f9f-a039-f82b0df6b378.png) |  ![Screenshot from 2021-08-23 14-19-14](https://user-images.githubusercontent.com/20267363/130471452-fcc4f961-10ca-4e63-9d34-f164bdf4a334.png)

### `/api/posts` endpoint (with posts containing a number of mentions)
Before | After
-- | --
![Screenshot from 2021-08-23 16-13-11](https://user-images.githubusercontent.com/20267363/130472185-a8113085-c67f-4fc7-a781-46516c814fc3.png) | ![Screenshot from 2021-08-23 16-13-27](https://user-images.githubusercontent.com/20267363/130472263-85a219c6-4acd-4111-b09a-e3887e93efd2.png)

### `/api/discussions/{id}` endpoint (discussions with posts containing a number of mentions)
Before | After
-- | --
![Screenshot from 2021-08-23 15-19-47](https://user-images.githubusercontent.com/20267363/130471570-0ea1df49-f61c-4011-bcce-a9803a76a2ae.png) | ![Screenshot from 2021-08-23 15-57-48](https://user-images.githubusercontent.com/20267363/130471672-09a0b48b-5dc9-487d-95d0-5d4d847e9fc8.png)

