### PR TITLE
Only search users via rest API if user has permission

### DIFF
--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -224,7 +224,7 @@ export default function addComposerAutocomplete() {
 
         // Don't send API calls searching for users until at least 2 characters have been typed.
         // This focuses the mention results on users and posts in the discussion.
-        if (typed.length > 1) {
+        if (typed.length > 1 && app.forum.attribute('canSearchUsers')) {
           throttledSearch(typed, searched, returnedUsers, returnedUserIds, dropdown, buildSuggestions);
         }
       }


### PR DESCRIPTION
Closes https://github.com/flarum/core/issues/3070

If the user doesn't have permission to search users, there will currently be browser errors, as the current implementation will still attempt to search and autocomplete. In this PR, we check for permission before searching. The dropdown will still support autocomplete of users currently participating in the discussion.