### PR TITLE
fix: Missing `#` from autocompleted user mention format

### DIFF
--- a/js/src/forum/utils/getMentionText.js
+++ b/js/src/forum/utils/getMentionText.js
@@ -27,7 +27,7 @@ export default function getMentionText(user, postId) {
     }
     // @"Display name"#UserID
     const cleanText = getCleanDisplayName(user);
-    return `@"${cleanText}"${user.id()}`;
+    return `@"${cleanText}"#${user.id()}`;
   } else {
     // @"Display name"#pPostID
     const cleanText = getCleanDisplayName(user);


### PR DESCRIPTION
**Fixes flarum/core#3112**

**Changes proposed in this pull request:**
A simple missing `#` from the user mention format on the frontend.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.