### PR TITLE
fix: autocomplete errors with TextEditor re-use

### DIFF
--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -66,7 +66,7 @@ export default function addComposerAutocomplete() {
     const returnedUserIds = new Set(returnedUsers.map((u) => u.id()));
 
     const applySuggestion = (replacement) => {
-      app.composer.editor.replaceBeforeCursor(absMentionStart - 1, replacement + ' ');
+      this.attrs.composer.editor.replaceBeforeCursor(absMentionStart - 1, replacement + ' ');
 
       dropdown.hide();
     };


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Re-using the TextEditor outside of the composer causes errors, as this extension attempts to access `app.composer` instead of `this.attrs.composer`.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
