### PR TITLE
fix: unnecessary user searches for completed mentions

### DIFF
--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -97,7 +97,24 @@ export default function addComposerAutocomplete() {
 
       if (absMentionStart) {
         typed = lastChunk.substring(relMentionStart).toLowerCase();
-        matchTyped = typed.match(/^["|“]((?:(?!"#).)+)$/);
+        /**
+         * Match descriptions:
+         * [0] - full string
+         * [1] - first quote
+         * [2] - username/display name search query
+         * [3] - (optional) end quote and hash
+         *
+         * We can check is capture group 3 exists to see if the string matches
+         * a full mention or not, which can prevent us searching unnecessarily.
+         *
+         * @example
+         * `"davwheat 123"#p1234`
+         *  ^------------------^    [0]
+         *  ^                       [1]
+         *   ^----------^           [2]
+         *                ^----^    [3]
+         */
+        matchTyped = typed.match(/^(["“])(.+?)((?:\1#)p?\d*)?$/);
         typed = (matchTyped && matchTyped[1]) || typed;
 
         const makeSuggestion = function (user, replacement, content, className = '') {
@@ -225,7 +242,7 @@ export default function addComposerAutocomplete() {
 
         // Don't send API calls searching for users until at least 2 characters have been typed.
         // This focuses the mention results on users and posts in the discussion.
-        if (typed.length > 1 && app.forum.attribute('canSearchUsers')) {
+        if (matchTyped[3] === undefined && typed.length > 1 && app.forum.attribute('canSearchUsers')) {
           throttledSearch(typed, searched, returnedUsers, returnedUserIds, dropdown, buildSuggestions);
         }
       }


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

Fixed QA issue raised by @luceos

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- checks for a completed mention
- only fires an XHR if the mention syntax is **not** complete

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Is there a better regex we can use? Anything else to add to the var docblock?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
Issue:
![image](https://user-images.githubusercontent.com/7406822/149561799-f0f05b5e-f920-4fac-a381-af63283b5c59.png)


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

