### PR TITLE
use isCollapsed instead of rangeCount

### DIFF
--- a/js/src/forum/utils/selectedText.js
+++ b/js/src/forum/utils/selectedText.js
@@ -4,7 +4,7 @@
 export default function selectedText(body) {
   const selection = window.getSelection();
 
-  if (selection?.rangeCount) {
+  if (!selection.isCollapsed) {
     const range = selection.getRangeAt(0);
     const parent = range.commonAncestorContainer;
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
Currently we're using `rangeCount` property to check whether or not there is currently any text selected. But as per MDN Docs when an user clicks on a freshly loaded page, the `rangeCount` evaluates to `1` - even if there isn't any selection. I think we should use `isCollapsed` instead.

See:
https://developer.mozilla.org/en-US/docs/Web/API/Selection/rangeCount
https://developer.mozilla.org/en-US/docs/Web/API/Selection/isCollapsed

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
